### PR TITLE
feat: ERC2612 (permit)機能の実装

### DIFF
--- a/packages/contract/contracts/FORToken.sol
+++ b/packages/contract/contracts/FORToken.sol
@@ -2,13 +2,14 @@
 pragma solidity ^0.8.28;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 
-contract FORToken is ERC20 {
+contract FORToken is ERC20, ERC20Permit {
     constructor(
         uint256 initialSupply,
         string memory name,
         string memory symbol
-    ) ERC20(name, symbol) {
+    ) ERC20(name, symbol) ERC20Permit(name) {
         _mint(msg.sender, initialSupply);
     }
 }


### PR DESCRIPTION
- FORTokenにERC20Permitを継承
- permit(), nonces(), DOMAIN_SEPARATOR()メソッドを追加
- TypeScriptテストに5つの新しいテストケースを追加
- Solidityテストに7つの新しいテストケース(ファズテスト含む)を追加
- すべてのテストが正常にパス (Solidity: 38/38, TypeScript: 15/15)