### PR TITLE
feat(indexer): AllowListイベントのインデックス追加

### DIFF
--- a/packages/indexer/config/base.json
+++ b/packages/indexer/config/base.json
@@ -1,5 +1,7 @@
 {
   "network": "base",
-  "address": "0x0000000000000000000000000000000000000000",
-  "startBlock": 0
+  "routerAddress": "0x0000000000000000000000000000000000000000",
+  "routerStartBlock": 0,
+  "forTokenAddress": "0x0000000000000000000000000000000000000000",
+  "forTokenStartBlock": 0
 }

--- a/packages/indexer/config/localhost.json
+++ b/packages/indexer/config/localhost.json
@@ -1,5 +1,7 @@
 {
   "network": "localhost",
-  "address": "0x00107E2ff2a6F2658D338F5A9dE05A86791f0268",
-  "startBlock": 0
+  "routerAddress": "0x00107E2ff2a6F2658D338F5A9dE05A86791f0268",
+  "routerStartBlock": 0,
+  "forTokenAddress": "0x0000000000000000000000000000000000000000",
+  "forTokenStartBlock": 0
 }

--- a/packages/indexer/config/sepolia.json
+++ b/packages/indexer/config/sepolia.json
@@ -1,5 +1,7 @@
 {
   "network": "sepolia",
-  "address": "0x4cd440C31a990185759499e6026EB5278D61cCB6",
-  "startBlock": 10650912
+  "routerAddress": "0x4cd440C31a990185759499e6026EB5278D61cCB6",
+  "routerStartBlock": 10650912,
+  "forTokenAddress": "0xa747Df53d79805eB05Bc970729c5B61478173b3b",
+  "forTokenStartBlock": 10650899
 }

--- a/packages/indexer/schema.graphql
+++ b/packages/indexer/schema.graphql
@@ -32,3 +32,13 @@ type User @entity(immutable: false) {
   executedTransfers: [Transfer!]! @derivedFrom(field: "sender")
   ratioChanges: [DistributionRatio!]! @derivedFrom(field: "changedBy")
 }
+
+type AllowedUser @entity(immutable: false) {
+  id: ID!
+  isAllowed: Boolean!
+  addedAtBlock: BigInt!
+  addedAtTimestamp: BigInt!
+  updatedAtBlock: BigInt!
+  updatedAtTimestamp: BigInt!
+  updatedAtTransactionHash: Bytes!
+}

--- a/packages/indexer/src/mapping.ts
+++ b/packages/indexer/src/mapping.ts
@@ -1,9 +1,21 @@
 // biome-ignore lint/style/useImportType: graph-ts mappings are compiled by AssemblyScript and require this import form.
+import { ethereum } from "@graphprotocol/graph-ts";
+// biome-ignore lint/style/useImportType: graph-ts mappings are compiled by AssemblyScript and require this import form.
+import {
+  AllowListAdded as AllowListAddedEvent,
+  AllowListRemoved as AllowListRemovedEvent,
+} from "../generated/FoRToken/FoRToken";
+// biome-ignore lint/style/useImportType: graph-ts mappings are compiled by AssemblyScript and require this import form.
 import {
   DistributionRatioUpdated as DistributionRatioUpdatedEvent,
   TransferWithDistribution as TransferWithDistributionEvent,
 } from "../generated/Router/Router";
-import { DistributionRatio, Transfer, User } from "../generated/schema";
+import {
+  AllowedUser,
+  DistributionRatio,
+  Transfer,
+  User,
+} from "../generated/schema";
 
 function upsertUser(address: string): void {
   let user = User.load(address);
@@ -11,6 +23,24 @@ function upsertUser(address: string): void {
     user = new User(address);
     user.save();
   }
+}
+
+function upsertAllowedUser(
+  account: string,
+  isAllowed: boolean,
+  event: ethereum.Event,
+): void {
+  let allowed = AllowedUser.load(account);
+  if (allowed == null) {
+    allowed = new AllowedUser(account);
+    allowed.addedAtBlock = event.block.number;
+    allowed.addedAtTimestamp = event.block.timestamp;
+  }
+  allowed.isAllowed = isAllowed;
+  allowed.updatedAtBlock = event.block.number;
+  allowed.updatedAtTimestamp = event.block.timestamp;
+  allowed.updatedAtTransactionHash = event.transaction.hash;
+  allowed.save();
 }
 
 export function handleTransferWithDistribution(
@@ -61,4 +91,16 @@ export function handleDistributionRatioUpdated(
   ratio.logIndex = event.logIndex;
 
   ratio.save();
+}
+
+export function handleAllowListAdded(event: AllowListAddedEvent): void {
+  const account = event.params.account.toHexString();
+  upsertUser(account);
+  upsertAllowedUser(account, true, event);
+}
+
+export function handleAllowListRemoved(event: AllowListRemovedEvent): void {
+  const account = event.params.account.toHexString();
+  upsertUser(account);
+  upsertAllowedUser(account, false, event);
 }

--- a/packages/indexer/subgraph.template.yaml
+++ b/packages/indexer/subgraph.template.yaml
@@ -7,9 +7,9 @@ dataSources:
     name: Router
     network: {{network}}
     source:
-      address: "{{address}}"
+      address: "{{routerAddress}}"
       abi: Router
-      startBlock: {{startBlock}}
+      startBlock: {{routerStartBlock}}
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9
@@ -26,4 +26,28 @@ dataSources:
           handler: handleTransferWithDistribution
         - event: DistributionRatioUpdated(indexed address,uint256,uint256,uint256)
           handler: handleDistributionRatioUpdated
+      file: ./src/mapping.ts
+
+  - kind: ethereum/contract
+    name: FoRToken
+    network: {{network}}
+    source:
+      address: "{{forTokenAddress}}"
+      abi: FoRToken
+      startBlock: {{forTokenStartBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      entities:
+        - AllowedUser
+        - User
+      abis:
+        - name: FoRToken
+          file: ../contract/artifacts/contracts/FoRToken.sol/FoRToken.json
+      eventHandlers:
+        - event: AllowListAdded(indexed address)
+          handler: handleAllowListAdded
+        - event: AllowListRemoved(indexed address)
+          handler: handleAllowListRemoved
       file: ./src/mapping.ts


### PR DESCRIPTION
## 関連 Issue

Closes #96

## 変更内容

- FoRTokenコントラクトを subgraph の dataSource として追加し、`AllowListAdded` / `AllowListRemoved` イベントをインデックス
- `AllowedUser` エンティティ（`isAllowed` フラグ・add/update タイムスタンプ）を `schema.graphql` に追加
- `handleAllowListAdded` / `handleAllowListRemoved` ハンドラと `upsertAllowedUser` ヘルパーを `src/mapping.ts` に実装
- `config/*.json` の既存キー `address` / `startBlock` を `routerAddress` / `routerStartBlock` にリネームし、`forTokenAddress` / `forTokenStartBlock` を新設（Sepolia は FoRToken 実アドレス `0xa747Df53d79805eB05Bc970729c5B61478173b3b` / block `10650899`、base と localhost はプレースホルダ）

`allowedUsers(where: { isAllowed: true }) { id }` のようなクエリで現在の許可済みユーザー一覧が取得可能になります。

## 動作確認

- [x] ローカル環境で動作確認済み (`pnpm codegen:sepolia` / `pnpm build:sepolia` で型生成と WASM コンパイルが成功)
- [x] ビルドが成功することを確認済み

## その他

- subgraph の再デプロイは後続 issue (#97 / #98 / #99) の indexer 対応がまとまった後にまとめて実施する予定です
- 後続 issue: #97 (`Transfer` → `TransferViaRouter` リネーム)、#98 (ERC20 純粋 Transfer)、#99 (累計納税額) は本 PR のスコープ外

🤖 Generated with [Claude Code](https://claude.com/claude-code)