### PR TITLE
feat: ホーム画面のウォレット残高を実データに接続 (#90)

### DIFF
--- a/packages/frontend/app/routes/home.tsx
+++ b/packages/frontend/app/routes/home.tsx
@@ -14,6 +14,7 @@ import { ListRow } from "~/components/ui/list-row";
 import { SectionTitle } from "~/components/ui/section-title";
 import { Tabs, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { useActiveWallet } from "~/hooks/useActiveWallet";
+import { useForTokenBalance } from "~/hooks/useForToken";
 import type { NameStoneProfile } from "~/lib/namestone.server";
 import type { Route } from "./+types/home";
 
@@ -92,6 +93,7 @@ const dummyOsusowake = [
 function AuthenticatedHome() {
   const navigate = useNavigate();
   const { address, isLoading: isWalletLoading } = useActiveWallet();
+  const { data: balance, isLoading: isBalanceLoading } = useForTokenBalance(address);
   const fetcher = useFetcher<{ profile: NameStoneProfile | null }>();
   const [checked, setChecked] = useState(false);
 
@@ -152,7 +154,7 @@ function AuthenticatedHome() {
         {/* Wallet Card */}
         <Card
           variant="wallet"
-          amount={34393}
+          amount={isBalanceLoading ? "--" : balance ? Number(balance.formatted) : 0}
           topProps={{
             badgeImage: "",
           }}


### PR DESCRIPTION
## 関連 Issue

Closes #90

## 変更内容

- `home.tsx` の Wallet Card にハードコードされていた残高 (`34393`) を削除しました。
- `useForTokenBalance` フックをインポートし、ログインユーザーの実際の実データ（FoRトークン残高）を取得・表示するように変更しました。
- データ取得中（ローディング中）は、残高部分に `--` が表示されるように実装しました。

## 動作確認

- [x] ローカル環境で動作確認済み
- [x] テストが通ることを確認済み（型チェック完了）
- [x] ビルドが成功することを確認済み

## スクリーンショット（該当する場合）

<img width="1021" height="1088" alt="スクリーンショット 2026-04-13 21 57 28" src="https://github.com/user-attachments/assets/1bab96b1-9971-4f96-8a97-36557be9c345" />


## その他
