### PR TITLE
feat(frontend): Sepolia開発モード追加・マイページにログアウトボタン追加

### DIFF
--- a/packages/frontend/.gitignore
+++ b/packages/frontend/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .env
 .env*.local
+.env.sepolia
 /node_modules/
 
 # GraphQL Codegen

--- a/packages/frontend/app/routes/mypage.tsx
+++ b/packages/frontend/app/routes/mypage.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
-import { Link, useFetcher } from "react-router";
+import { usePrivy } from "@privy-io/react-auth";
+import { Link, useFetcher, useNavigate } from "react-router";
 import {
   AppBar,
   AppBarItem,
@@ -22,7 +23,14 @@ function shortenAddress(address: string): string {
 
 export default function Mypage() {
   const { address, isLoading: isWalletLoading } = useActiveWallet();
+  const { logout } = usePrivy();
+  const navigate = useNavigate();
   const fetcher = useFetcher<{ profile: NameStoneProfile | null }>();
+
+  const handleLogout = async () => {
+    await logout();
+    navigate("/");
+  };
 
   useEffect(() => {
     if (address && fetcher.state === "idle" && !fetcher.data) {
@@ -117,6 +125,10 @@ export default function Mypage() {
             <Button className="w-full">プロフィールを作成</Button>
           </Link>
         )}
+
+        <Button variant="secondary" className="w-full" onClick={handleLogout}>
+          ログアウト
+        </Button>
       </div>
     </div>
   );

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "react-router build",
     "dev": "react-router dev",
+    "dev:sepolia": "react-router dev --mode sepolia",
     "start": "react-router-serve ./build/server/index.js",
     "typegen": "react-router typegen",
     "check": "biome check",


### PR DESCRIPTION
## 関連 Issue

N/A

## 変更内容

- `pnpm dev:sepolia` でSepolia接続の開発サーバーを起動できるようにした（`--mode sepolia` で `.env.sepolia` を読み込み）
- `.env.sepolia` を `.gitignore` に追加（APIキー漏洩防止）
- マイページにログアウトボタンを追加（Privy の `logout()` でウォレット切断後、ホームに遷移）

## 動作確認

- [ ] ローカル環境で動作確認済み
- [ ] テストが通ることを確認済み
- [ ] ビルドが成功することを確認済み

## スクリーンショット（該当する場合）

N/A

## その他

仮PRです。