### PR TITLE
ローカル開発環境セットアップガイド（全員最初に実施）

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,8 @@ FoRは [Comoris DAO](https://comoris.co/) と[Hackdays project](https://hackdays
 
 - Node.js >= 18.18.0
 - pnpm 9.12.0
+- Docker Desktop
+- VITE_PRIVY_APP_ID（運営から共有される値）
 
 ### セットアップ手順
 
@@ -52,12 +54,6 @@ cd FoR
 
 # 依存関係のインストール
 pnpm install
-
-# 全パッケージのビルド
-pnpm build
-
-# 開発サーバーの起動
-pnpm dev
 ```
 
 詳細な開発手順は [CLAUDE.md](./CLAUDE.md) をご確認ください。
@@ -66,9 +62,11 @@ pnpm dev
 
 コントラクト → Graph Node → インデクサー → フロントエンドを一気通貫で動かす手順です。
 
-**���提**: Docker が起動していること
+**前提**: Docker Desktop が起動していること
 
 #### 1. Hardhat ローカルノード起動
+
+ターミナル 1 で起動し、そのまま維持してください。
 
 ```bash
 pnpm dev:node
@@ -76,32 +74,67 @@ pnpm dev:node
 
 #### 2. コントラクトデプロイ & セットアップ
 
+ターミナル 2 で実行します。`setup:local` 実行後に表示される Router address を確認してください。
+
 ```bash
 cd packages/contract
-pnpm deploy:local        # FoRToken, RouterFactory, Router を順にデプロイ
-pnpm setup:local         # AllowList 設定 & Indexer の config 更新
+pnpm deploy:local
+pnpm setup:local
 ```
 
 #### 3. Graph Node 起動 & サブグラフデプロイ
 
-```bash
-pnpm dev:graph           # graph-node + PostgreSQL + IPFS をバックグラウンド起動
+ターミナル 3 で Graph Node を起動し、起動後にターミナル 4 で Indexer をデプロイします。
 
-cd packages/indexer
-pnpm create:localhost    # サブグラフ作成
-pnpm deploy:localhost    # サブグラフデプロイ
+```bash
+pnpm dev:graph
 ```
 
-GraphQL Playground: http://localhost:8000/subgraphs/name/for/localhost
+```bash
+# graph-node が起動してから実行
+cd packages/indexer
+pnpm create:localhost
+pnpm deploy:localhost
+```
+
+GraphQL Playground:
+
+- http://localhost:8000/subgraphs/name/for/localhost
 
 #### 4. フロントエンド起動
 
+まず `.env.example` をコピーして `.env` を作成し、ローカル向けの値を設定します。
+
 ```bash
-# packages/frontend/.env に VITE_CHAIN_ID=31337 を設定
-pnpm dev:frontend
+cp packages/frontend/.env.example packages/frontend/.env
 ```
 
-#### MetaMask にローカルネットワークを追加
+`.env` の設定内容:
+
+- `VITE_CHAIN_ID=31337`
+- `VITE_PRIVY_APP_ID=<運営から共有された値>`
+
+設定後、`packages/frontend` で起動します。
+
+```bash
+cd packages/frontend
+pnpm dev
+```
+
+#### 5. 動作確認
+
+- [ ] Hardhat ノードが起動している
+- [ ] コントラクトがデプロイ済み
+- [ ] Docker で `graph-node` / `IPFS` / `PostgreSQL` が起動している
+- [ ] Indexer がデプロイ済み
+- [ ] フロントエンドが起動し、Privy ログイン画面が表示される
+
+確認 URL:
+
+- http://localhost:5173
+- http://localhost:8000/subgraphs/name/for/localhost
+
+#### 6. MetaMask にローカルネットワークを追加
 
 | 項目 | 値 |
 |---|---|
@@ -120,13 +153,11 @@ pnpm dev:frontend
 
 #### リセット
 
-Hardhat ノードを再起動した場合は、Graph Node のデータもクリーンアップが必要です。
+Hardhat ノードを再起動した場合は、Graph Node のデータもクリーンアップが必要です。再起動後は `pnpm dev:graph:clean` を実行してから、手順 1 からやり直してください。
 
 ```bash
-pnpm dev:graph:clean     # docker compose down -v & データ削除
+pnpm dev:graph:clean
 ```
-
-その後、手順 1 からやり直してください。
 
 ## Issue と Pull Request について
 

--- a/README.md
+++ b/README.md
@@ -68,29 +68,87 @@ FoR/
 - **Graph Protocol (AssemblyScript)**: イベントマッピング
 - **GraphQL**: インデックス済みデータ取得
 
-## 🚀 セットアップ
+## 🚀 ローカルセットアップ
 
-### 環境要件
+### 必要な環境
 
-- Node.js >= 18.18.0
-- pnpm 9.12.0
+- Node.js `>= 18.18.0`
+- pnpm `9.12.0`
+- Docker Desktop
+- `VITE_PRIVY_APP_ID`（運営から共有される値）
 
-### インストール
+### 1. リポジトリクローン & 依存関係インストール
 
 ```bash
-# 依存関係のインストール
+git clone https://github.com/hackdays-io/FoR.git
+cd FoR
 pnpm install
-
-# コントラクトのビルド
-pnpm --filter contract build
-
-# フロントエンドの開発サーバー起動
-pnpm --filter frontend dev
 ```
+
+### 2. Hardhat ローカルノード起動
+
+別ターミナルで起動し、そのまま維持してください。
+
+```bash
+pnpm dev:node
+```
+
+### 3. コントラクトデプロイ & セットアップ
+
+別ターミナルで実行します。`setup:local` の出力に表示される Router address を確認してください。
+
+```bash
+cd packages/contract
+pnpm deploy:local
+pnpm setup:local
+```
+
+### 4. Graph Node 起動
+
+Docker Desktop が起動していることを確認してから実行します。
+
+```bash
+pnpm dev:graph
+```
+
+### 5. Indexer デプロイ
+
+`graph-node` が起動してから、別ターミナルで実行します。
+
+```bash
+cd packages/indexer
+pnpm create:localhost
+pnpm deploy:localhost
+```
+
+### 6. フロントエンド起動
+
+```bash
+cp packages/frontend/.env.example packages/frontend/.env
+```
+
+`.env` を開いて以下を設定してください。
+
+- `VITE_CHAIN_ID=31337`
+- `VITE_PRIVY_APP_ID=<運営から共有された値>`
+
+その後、別ターミナルでフロントエンドを起動します。
+
+```bash
+cd packages/frontend
+pnpm dev
+```
+
+### 7. 動作確認
+
+- `http://localhost:5173` にアクセスし、Privy ログインが表示されること
+- `http://localhost:8000/subgraphs/name/for/localhost` にアクセスし、GraphQL Playground が表示されること
+
+リセット手順や補足を含む詳細ガイドは [`CONTRIBUTING.md`](./CONTRIBUTING.md) を参照してください。
 
 ### パッケージ別コマンド
 
-#### コントラクト (packages/contract/)
+#### コントラクト (`packages/contract/`)
 
 ```bash
 cd packages/contract
@@ -101,11 +159,12 @@ pnpm build
 # テスト
 pnpm test
 
-# デプロイ
-pnpm deploy
+# ローカルデプロイ
+pnpm deploy:local
+pnpm setup:local
 ```
 
-#### フロントエンド (packages/frontend/)
+#### フロントエンド (`packages/frontend/`)
 
 ```bash
 cd packages/frontend
@@ -116,28 +175,24 @@ pnpm dev
 # プロダクションビルド
 pnpm build
 
-# 型チェック
-pnpm typecheck
+# React Router の型生成
+pnpm typegen
 ```
 
-#### インデクサー (packages/indexer/)
+#### インデクサー (`packages/indexer/`)
 
 ```bash
 cd packages/indexer
 
-# codegen
-pnpm codegen
+# localhost 向けサブグラフ作成
+pnpm create:localhost
 
-# サブグラフのビルド
-pnpm build
+# localhost 向けサブグラフデプロイ
+pnpm deploy:localhost
 
-# Sepoliaへのデプロイ
+# Sepolia へのデプロイ
 pnpm deploy:sepolia
 ```
-
-### Indexer Endpoint
-
-- Sepolia GraphQL endpoint: `<set-after-deploy>`
 
 ## 📚 ドキュメント
 

--- a/packages/contract/scripts/setup-local.ts
+++ b/packages/contract/scripts/setup-local.ts
@@ -166,8 +166,11 @@ console.log(`  Router address: ${routerAddress}`);
 console.log("\n=== Setup Complete ===");
 console.log(`
 Next steps:
-  1. Start Graph Node:  pnpm dev:graph
-  2. Create subgraph:   cd packages/indexer && pnpm create:localhost
-  3. Deploy subgraph:   cd packages/indexer && pnpm deploy:localhost
-  4. Start frontend:    cd packages/frontend && pnpm dev
+  1. Confirm Router address above for local setup and indexer config.
+  2. Start Graph Node:   pnpm dev:graph
+  3. Create subgraph:    cd packages/indexer && pnpm create:localhost
+  4. Deploy subgraph:    cd packages/indexer && pnpm deploy:localhost
+  5. Create frontend env: cp packages/frontend/.env.example packages/frontend/.env
+  6. Update frontend env: set VITE_CHAIN_ID=31337 and VITE_PRIVY_APP_ID=<shared value>
+  7. Start frontend:     cd packages/frontend && pnpm dev
 `);

--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -17,7 +17,7 @@ VITE_PIMLICO_API_KEY=your-pimlico-api-key-here
 
 # Subgraph URL (leave empty for auto-configuration based on chain ID)
 # Local:   http://localhost:8000/subgraphs/name/for/localhost
-# Sepolia: https://api.goldsky.com/api/public/project_cm5nv64onnxxz01wf8smdgk1e/subgraphs/for-sepolia/0.0.0/gn
+# Sepolia: https://api.goldsky.com/api/public/project_cm5nv64onnxxz01wf8smdgk1e/subgraphs/for-sepolia/0.0.1/gn
 VITE_SUBGRAPH_URL=
 
 # NameStone API Key (get from https://namestone.com)

--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -1,7 +1,12 @@
-# Privy App ID (get from https://console.privy.io)
+# Local setup note:
+# - copy this file to packages/frontend/.env
+# - VITE_PRIVY_APP_ID is required for local login and should use the value shared by the team
+# - set VITE_CHAIN_ID=31337 when connecting to the local Hardhat node
+
+# Privy App ID (get from https://console.privy.io or use the value shared by the team)
 VITE_PRIVY_APP_ID=your-privy-app-id-here
 
-# Chain ID (11155111=Sepolia, 8453=Base)
+# Chain ID (31337=Local, 11155111=Sepolia, 8453=Base)
 VITE_CHAIN_ID=11155111
 
 # Alchemy API Key (get from https://dashboard.alchemy.com)
@@ -11,7 +16,7 @@ VITE_ALCHEMY_KEY=your-alchemy-key-here
 VITE_PIMLICO_API_KEY=your-pimlico-api-key-here
 
 # Subgraph URL (leave empty for auto-configuration based on chain ID)
-# Local: http://localhost:8000/subgraphs/name/for/localhost
+# Local:   http://localhost:8000/subgraphs/name/for/localhost
 # Sepolia: https://api.goldsky.com/api/public/project_cm5nv64onnxxz01wf8smdgk1e/subgraphs/for-sepolia/0.0.0/gn
 VITE_SUBGRAPH_URL=
 

--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -16,7 +16,7 @@ VITE_ALCHEMY_KEY=your-alchemy-key-here
 VITE_PIMLICO_API_KEY=your-pimlico-api-key-here
 
 # Subgraph URL (leave empty for auto-configuration based on chain ID)
-# Local:   http://localhost:8000/subgraphs/name/for/localhost
+# Local: http://localhost:8000/subgraphs/name/for/localhost
 # Sepolia: https://api.goldsky.com/api/public/project_cm5nv64onnxxz01wf8smdgk1e/subgraphs/for-sepolia/0.0.1/gn
 VITE_SUBGRAPH_URL=
 


### PR DESCRIPTION
## 関連 Issue

closes #81 

## 変更内容

- `README.md` をローカル開発環境構築の入口として更新し、clone から frontend 起動までの導線を Issue の手順順に整理
- `CONTRIBUTING.md` の「ローカル開発環境構築」を詳細版として更新し、別ターミナル運用、Router address 確認、`pnpm dev:graph:clean` を含むリセット手順、確認項目を明記
- `packages/frontend/.env.example` と `packages/contract/scripts/setup-local.ts` を更新し、`VITE_PRIVY_APP_ID` / `VITE_CHAIN_ID=31337` の案内と次の手順を分かりやすくした

### やったこと

- Docker Desktop と `VITE_PRIVY_APP_ID` を前提条件として追加
- コントラクトデプロイ、Graph Node 起動、Indexer デプロイ、frontend 設定までのローカルセットアップ手順を README / CONTRIBUTING に反映
- `.env.example` のコメントを更新し、ローカル向けの設定方法を明確化
- `setup-local.ts` の完了メッセージを更新し、Router address 確認と frontend 起動前の設定手順を案内

### やってないこと

- Privy のローカル fallback 実装
- 新しい helper script / doctor command の追加
- 既存 UI / contract / indexer の挙動変更

## 動作確認

- [x] ローカル環境で動作確認済み
- [ ] テストが通ることを確認済み
- [ ] ビルドが成功することを確認済み

## スクリーンショット（該当する場合）

- UI変更ではないためなし

## その他

- 以下はローカルで実際に確認済みです
  - `pnpm dev:node`
  - `cd packages/contract && pnpm deploy:local && pnpm setup:local`
  - `pnpm dev:graph`
  - `cd packages/indexer && pnpm create:localhost && pnpm deploy:localhost`
  - `cd packages/frontend && pnpm dev`
- `http://localhost:8000/subgraphs/name/for/localhost` への GraphQL query は成功しました
- frontend は dev server 起動まで確認していますが、ログイン画面の最終確認には運営共有の有効な `VITE_PRIVY_APP_ID` が必要です
- 現在の実行環境では Node.js `v25.4.0` で Hardhat の warning が出たため、実運用では Node 22 LTS 系の利用が安全です
