### PR TITLE
fix: useActiveWalletをContext化してisSmartWalletを安定化

### DIFF
--- a/packages/frontend/app/hooks/useActiveWallet.ts
+++ b/packages/frontend/app/hooks/useActiveWallet.ts
@@ -1,72 +1,19 @@
-import { type ConnectedWallet, usePrivy, useWallets } from "@privy-io/react-auth";
-import type { Address } from "viem";
+import { useContext } from "react";
 
 import {
-  type SmartAccountClientType,
-  useSmartAccount,
-} from "./useSmartAccount";
-import {
-  type EOAWalletClient,
-  useHasEmbeddedWallet,
-  useWallet,
-} from "./useWallet";
+  ActiveWalletContext,
+  type ActiveWalletContextValue,
+  type WalletType,
+} from "~/providers/ActiveWalletProvider";
 
-/**
- * Unified wallet type for SmartAccountClient and EOA WalletClient
- * Compatible with toban's WalletType
- * Use wallet.account?.address for generalized address access
- */
-export type WalletType = SmartAccountClientType | EOAWalletClient | undefined;
+export type { WalletType };
 
-interface ActiveWalletResult {
-  wallet: WalletType;
-  address: Address | null;
-  connectedWallet: ConnectedWallet | undefined;
-  isSmartWallet: boolean;
-  isConnectingEmbeddedWallet: boolean;
-  isLoading: boolean;
-}
-
-/**
- * Check if the Privy user has an embedded wallet via user object.
- * This is available immediately on reload, unlike useWallets().
- */
-function useHasEmbeddedWalletFromUser(): boolean {
-  const { user } = usePrivy();
-  return user?.wallet?.walletClientType === "privy";
-}
-
-/**
- * Unified wallet interface hook
- * Selects Smart Account for embedded wallets, EOA otherwise
- */
-export function useActiveWallet(): ActiveWalletResult {
-  const { walletClient, connectedWallet, address: eoaAddress } = useWallet();
-  const {
-    smartAccountClient,
-    smartAccountAddress,
-    isLoading: isSmartAccountLoading,
-  } = useSmartAccount();
-  const { ready: walletsReady } = useWallets();
-  const hasEmbeddedFromWallets = useHasEmbeddedWallet();
-  const hasEmbeddedFromUser = useHasEmbeddedWalletFromUser();
-
-  // Use user object for immediate detection, wallets hook as fallback
-  const isConnectingEmbeddedWallet = hasEmbeddedFromWallets || hasEmbeddedFromUser;
-
-  const wallet = isConnectingEmbeddedWallet ? smartAccountClient : walletClient;
-  const address = isConnectingEmbeddedWallet ? smartAccountAddress : eoaAddress;
-
-  // Loading if: wallets SDK not ready, or embedded wallet detected but smart account still initializing
-  const isLoading =
-    !walletsReady || (isConnectingEmbeddedWallet && isSmartAccountLoading);
-
-  return {
-    wallet,
-    address,
-    connectedWallet,
-    isSmartWallet: !!smartAccountClient,
-    isConnectingEmbeddedWallet,
-    isLoading,
-  };
+export function useActiveWallet(): ActiveWalletContextValue {
+  const ctx = useContext(ActiveWalletContext);
+  if (!ctx) {
+    throw new Error(
+      "useActiveWallet must be used within ActiveWalletProvider",
+    );
+  }
+  return ctx;
 }

--- a/packages/frontend/app/providers/ActiveWalletProvider.tsx
+++ b/packages/frontend/app/providers/ActiveWalletProvider.tsx
@@ -1,0 +1,70 @@
+import { type ConnectedWallet, usePrivy, useWallets } from "@privy-io/react-auth";
+import { createContext, type ReactNode } from "react";
+import type { Address } from "viem";
+
+import {
+  type SmartAccountClientType,
+  useSmartAccount,
+} from "~/hooks/useSmartAccount";
+import {
+  type EOAWalletClient,
+  useHasEmbeddedWallet,
+  useWallet,
+} from "~/hooks/useWallet";
+
+export type WalletType = SmartAccountClientType | EOAWalletClient | undefined;
+
+export interface ActiveWalletContextValue {
+  wallet: WalletType;
+  address: Address | null;
+  connectedWallet: ConnectedWallet | undefined;
+  isSmartWallet: boolean;
+  isConnectingEmbeddedWallet: boolean;
+  isLoading: boolean;
+}
+
+export const ActiveWalletContext =
+  createContext<ActiveWalletContextValue | null>(null);
+
+function useHasEmbeddedWalletFromUser(): boolean {
+  const { user } = usePrivy();
+  return user?.wallet?.walletClientType === "privy";
+}
+
+export function ActiveWalletProvider({ children }: { children: ReactNode }) {
+  const { walletClient, connectedWallet, address: eoaAddress } = useWallet();
+  const {
+    smartAccountClient,
+    smartAccountAddress,
+    isLoading: isSmartAccountLoading,
+  } = useSmartAccount();
+  const { ready: walletsReady } = useWallets();
+  const hasEmbeddedFromWallets = useHasEmbeddedWallet();
+  const hasEmbeddedFromUser = useHasEmbeddedWalletFromUser();
+
+  const isConnectingEmbeddedWallet =
+    hasEmbeddedFromWallets || hasEmbeddedFromUser;
+
+  const wallet = isConnectingEmbeddedWallet ? smartAccountClient : walletClient;
+  const address = isConnectingEmbeddedWallet ? smartAccountAddress : eoaAddress;
+
+  const isLoading =
+    !walletsReady || (isConnectingEmbeddedWallet && isSmartAccountLoading);
+
+  const isSmartWallet = !!smartAccountClient;
+
+  const value: ActiveWalletContextValue = {
+    wallet,
+    address,
+    connectedWallet,
+    isSmartWallet,
+    isConnectingEmbeddedWallet,
+    isLoading,
+  };
+
+  return (
+    <ActiveWalletContext.Provider value={value}>
+      {children}
+    </ActiveWalletContext.Provider>
+  );
+}

--- a/packages/frontend/app/root.tsx
+++ b/packages/frontend/app/root.tsx
@@ -9,6 +9,7 @@ import {
 import type { Route } from "./+types/root";
 import "./app.css";
 import { AuthGate } from "./components/auth-gate";
+import { ActiveWalletProvider } from "./providers/ActiveWalletProvider";
 import { AppPrivyProvider } from "./providers/AppPrivyProvider";
 import { QueryProvider } from "./providers/QueryProvider";
 
@@ -47,9 +48,11 @@ export default function App() {
   return (
     <QueryProvider>
       <AppPrivyProvider>
-        <div className="mx-auto w-full max-w-md min-h-screen">
-          <AuthGate />
-        </div>
+        <ActiveWalletProvider>
+          <div className="mx-auto w-full max-w-md min-h-screen">
+            <AuthGate />
+          </div>
+        </ActiveWalletProvider>
       </AppPrivyProvider>
     </QueryProvider>
   );

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -13,7 +13,6 @@
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "rootDirs": [".", "./.react-router/types"],
-    "baseUrl": ".",
     "paths": {
       "~/*": ["./app/*"]
     },


### PR DESCRIPTION
## 変更内容

- `ActiveWalletProvider` を新設し、`useActiveWallet` を `useContext` で値を取るだけの薄い hook に置き換え
- `useActiveWallet` / `useSmartAccount` / `useWallet` の呼び出しが複数コンポーネントで独立に走り、各インスタンスが別の state を持つ状態を解消
- `root.tsx` で `<AppPrivyProvider>` の内側に `<ActiveWalletProvider>` を配置し、単一の source of truth に
- 併せて `packages/frontend/tsconfig.json` の `baseUrl` を削除（TS v7 / tsgo で警告対象になるため。`paths` 単体で `~/*` エイリアスは維持）

## 背景・原因

`isSmartWallet` が embedded wallet 接続後も安定して `true` にならない挙動が発生していた。調査の結果、原因はコンポーネントツリー内で `useActiveWallet()` を呼んでいる箇所（`auth-gate`, `home`, `mypage`, `welcome`, `useAllowList`, `useRouter`, ...）それぞれが、内部で独立した `useSmartAccount` インスタンスを持ち、それぞれが:

1. 独自に Smart Account 初期化を走らせる
2. `useWallets()` が毎 render で新しい配列を返すため、`useEffect([embeddedWallet])` が再実行されて **client を一時的に undefined に戻してから再生成**

を繰り返していた。結果として、あるコンポーネントでは `isSmartWallet: true`、別のコンポーネントでは `false` が同時刻に共存し、さらに同じ hook 内でも true→false→true→... と振動していた。

Provider で値を持ち上げ、`useSmartAccount` が 1 度だけ初期化されるようにすることで、`isSmartWallet` は一度 `true` になれば継続的に `true` を保つようになる。

## 動作確認

- [x] ローカル環境で動作確認済み（sepolia, Privy email ログイン）
  - 修正前: `isSmartWallet` が true と false を往復し、`auth-gate` が LoadingScreen に留まる、あるいはコンポーネントによって値が食い違う
  - 修正後: embedded wallet 検出 → Smart Account 初期化 → `isSmartWallet: true` が安定継続
- [x] \`tsc --noEmit\` 通過
- [ ] テスト: 対象 hook のテストは既存なし