### PR TITLE
feat: BlockExplorerへのトランザクションリンクを追加 (#113)

### DIFF
--- a/packages/frontend/app/components/ui/list-row.stories.tsx
+++ b/packages/frontend/app/components/ui/list-row.stories.tsx
@@ -123,3 +123,21 @@ export const List = () => {
 };
 
 List.storyName = "List View";
+
+export const WithExternalLink = () => {
+  return (
+    <StoryFrame>
+      <ListRow
+        avatarSrc={SAMPLE_AVATAR}
+        name="りょうま"
+        message="草刈りありがとう！"
+        date="10/29 (水)"
+        amount={50}
+        externalUrl="https://etherscan.io/tx/0x0000000000000000000000000000000000000000000000000000000000000000"
+        externalUrlLabel="Etherscanで取引を開く"
+      />
+    </StoryFrame>
+  );
+};
+
+WithExternalLink.storyName = "With External Link";

--- a/packages/frontend/app/components/ui/list-row.tsx
+++ b/packages/frontend/app/components/ui/list-row.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from "lucide-react";
 import * as React from "react";
 
 import { formatAmount } from "~/lib/format";
@@ -20,6 +21,10 @@ export interface ListRowProps extends React.HTMLAttributes<HTMLDivElement> {
   unit?: string;
   /** 下部のdividerを表示するか（デフォルト: true） */
   divider?: boolean;
+  /** 行末に外部リンク（例: ブロックエクスプローラ）を表示する */
+  externalUrl?: string;
+  /** 外部リンクの aria-label */
+  externalUrlLabel?: string;
 }
 
 function formatSignedAmount(amount: number): string {
@@ -38,6 +43,8 @@ export const ListRow = React.forwardRef<HTMLDivElement, ListRowProps>(
       amount,
       unit = "FoR",
       divider = true,
+      externalUrl,
+      externalUrlLabel = "ブロックエクスプローラで開く",
       className,
       ...props
     },
@@ -97,6 +104,19 @@ export const ListRow = React.forwardRef<HTMLDivElement, ListRowProps>(
               </span>
             ) : null}
           </div>
+        ) : null}
+
+        {externalUrl ? (
+          <a
+            href={externalUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            aria-label={externalUrlLabel}
+            className="shrink-0 rounded-md p-4 text-muted-foreground hover:text-foreground"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <ExternalLink size={16} aria-hidden="true" />
+          </a>
         ) : null}
       </div>
     );

--- a/packages/frontend/app/lib/explorer.ts
+++ b/packages/frontend/app/lib/explorer.ts
@@ -1,0 +1,31 @@
+import type { Chain } from "viem";
+
+import { currentChain } from "./viem";
+
+function explorerBaseUrl(chain: Chain): string | null {
+  return chain.blockExplorers?.default.url ?? null;
+}
+
+export function getExplorerTxUrl(
+  txHash: string | null | undefined,
+  chain: Chain = currentChain,
+): string | null {
+  if (!txHash) return null;
+  const base = explorerBaseUrl(chain);
+  if (!base) return null;
+  return `${base.replace(/\/$/, "")}/tx/${txHash}`;
+}
+
+export function getExplorerAddressUrl(
+  address: string | null | undefined,
+  chain: Chain = currentChain,
+): string | null {
+  if (!address) return null;
+  const base = explorerBaseUrl(chain);
+  if (!base) return null;
+  return `${base.replace(/\/$/, "")}/address/${address}`;
+}
+
+export function getExplorerName(chain: Chain = currentChain): string {
+  return chain.blockExplorers?.default.name ?? "Explorer";
+}

--- a/packages/frontend/app/routes/send.tsx
+++ b/packages/frontend/app/routes/send.tsx
@@ -1,4 +1,4 @@
-import { X } from "lucide-react";
+import { ExternalLink, X } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { type Address, formatUnits, parseUnits } from "viem";
@@ -21,6 +21,7 @@ import {
 } from "~/hooks/useDistributionTransfer";
 import { useForTokenBalance } from "~/hooks/useForToken";
 import { useDistributionRatios } from "~/hooks/useRouter";
+import { getExplorerName, getExplorerTxUrl } from "~/lib/explorer";
 import { formatAmount } from "~/lib/format";
 import { getNamesByAddress } from "~/lib/namestone.server";
 import { buildMessagePayload } from "~/lib/transfer-message";
@@ -46,7 +47,11 @@ export async function loader({ request }: Route.LoaderArgs) {
     const profile = profiles.length > 0 ? profiles[0] : null;
     return { recipient: { address: to, profile }, initialAmount, initialStory };
   } catch {
-    return { recipient: { address: to, profile: null }, initialAmount, initialStory };
+    return {
+      recipient: { address: to, profile: null },
+      initialAmount,
+      initialStory,
+    };
   }
 }
 
@@ -74,17 +79,11 @@ function AmountRow({
 }) {
   return (
     <div className="flex items-center justify-between rounded-lg bg-background px-16 py-12">
-      <Typography
-        variant="ui-13"
-        weight={bold ? "bold" : "normal"}
-        as="span"
-      >
+      <Typography variant="ui-13" weight={bold ? "bold" : "normal"} as="span">
         {label}
       </Typography>
       <div className="flex items-baseline gap-4">
-        <Typography variant="number-m">
-          {formatAmount(amount)}
-        </Typography>
+        <Typography variant="number-m">{formatAmount(amount)}</Typography>
         <Typography variant="ui-20" weight="bold">
           FoR
         </Typography>
@@ -235,7 +234,12 @@ export default function Send({ loaderData }: Route.ComponentProps) {
                 placeholder="0"
                 className="min-w-0 flex-1 rounded-md border border-border bg-card px-8 py-6 text-right font-latin text-content-number-m font-bold text-foreground outline-none"
               />
-              <Typography variant="ui-20" weight="bold" as="span" className="shrink-0">
+              <Typography
+                variant="ui-20"
+                weight="bold"
+                as="span"
+                className="shrink-0"
+              >
                 FoR
               </Typography>
             </div>
@@ -255,7 +259,9 @@ export default function Send({ loaderData }: Route.ComponentProps) {
             </div>
 
             <div className="mt-12 flex items-center justify-between">
-              <Typography variant="ui-13" weight="bold" as="span">合計</Typography>
+              <Typography variant="ui-13" weight="bold" as="span">
+                合計
+              </Typography>
               <div className="flex items-baseline gap-4">
                 <Typography variant="number-l">
                   {isRatiosLoading ? "--" : formatAmount(totalAmount)}
@@ -318,7 +324,9 @@ export default function Send({ loaderData }: Route.ComponentProps) {
 
           {/* Story */}
           <div>
-            <Typography variant="ui-16" weight="bold">ストーリー</Typography>
+            <Typography variant="ui-16" weight="bold">
+              ストーリー
+            </Typography>
             <div className="mt-8">
               <TextField
                 placeholder="ストーリーをシェア"
@@ -420,7 +428,9 @@ export default function Send({ loaderData }: Route.ComponentProps) {
             </div>
 
             <div className="flex items-center justify-between pt-4">
-              <Typography variant="ui-13" weight="bold" as="span">合計</Typography>
+              <Typography variant="ui-13" weight="bold" as="span">
+                合計
+              </Typography>
               <div className="flex items-baseline gap-4">
                 <Typography variant="number-l">
                   {formatAmount(totalAmount)}
@@ -491,13 +501,32 @@ export default function Send({ loaderData }: Route.ComponentProps) {
           <AmountRow label="合計" amount={totalAmount} bold />
         </div>
 
+        {/* Explorer link */}
+        {(() => {
+          const explorerUrl = getExplorerTxUrl(txHash);
+          if (!explorerUrl) return null;
+          return (
+            <a
+              href={explorerUrl}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="inline-flex items-center gap-4 self-start text-ui-13 text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+            >
+              {getExplorerName()}で取引を見る
+              <ExternalLink size={14} aria-hidden="true" />
+            </a>
+          );
+        })()}
+
         {/* Rank */}
         <div className="flex flex-col items-center gap-8 pt-8">
           <Typography variant="ui-16" weight="bold" className="w-full">
             あなたのランク
           </Typography>
           <div className="h-[100px] w-[100px] rounded-lg bg-background" />
-          <Typography variant="ui-16" weight="bold">ランク2</Typography>
+          <Typography variant="ui-16" weight="bold">
+            ランク2
+          </Typography>
           <Typography variant="ui-13" className="text-visual-green-4">
             あと○回交換すると、ランク3にアップ！
           </Typography>

--- a/packages/frontend/app/routes/transactions.$address.tsx
+++ b/packages/frontend/app/routes/transactions.$address.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from "lucide-react";
 import { useMemo } from "react";
 import { useNavigate } from "react-router";
 import { formatUnits } from "viem";
@@ -15,6 +16,7 @@ import {
   type TransferBetween,
   useTransfersBetween,
 } from "~/hooks/useTransfersBetween";
+import { getExplorerName, getExplorerTxUrl } from "~/lib/explorer";
 import { formatAmount } from "~/lib/format";
 import { getNamesByAddress } from "~/lib/namestone.server";
 import { parseMessagePayload } from "~/lib/transfer-message";
@@ -54,6 +56,7 @@ function MessageBubble({
   amount,
   time,
   avatarSrc,
+  explorerUrl,
 }: {
   type: "sent" | "received";
   title: string;
@@ -62,6 +65,7 @@ function MessageBubble({
   amount: number;
   time: string;
   avatarSrc?: string;
+  explorerUrl: string | null;
 }) {
   const isSent = type === "sent";
 
@@ -88,6 +92,17 @@ function MessageBubble({
             FoR
           </Typography>
         </div>
+        {explorerUrl ? (
+          <a
+            href={explorerUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            aria-label={`${getExplorerName()}で取引を開く`}
+            className="self-end text-muted-foreground hover:text-foreground"
+          >
+            <ExternalLink size={14} aria-hidden="true" />
+          </a>
+        ) : null}
       </div>
       <Typography
         variant="ui-10"
@@ -123,6 +138,7 @@ interface ChatMessage {
   amount: number;
   time: string;
   date: string;
+  explorerUrl: string | null;
 }
 
 function buildMessages(
@@ -142,6 +158,7 @@ function buildMessages(
       amount: Number(formatUnits(BigInt(rawAmount), 18)),
       time: formatTime(tx.timestamp),
       date: formatTimestamp(tx.timestamp),
+      explorerUrl: getExplorerTxUrl(tx.transactionHash),
     };
   });
 }
@@ -211,6 +228,7 @@ export default function TransactionDetail({
                     amount={msg.amount}
                     time={msg.time}
                     avatarSrc={avatarSrc}
+                    explorerUrl={msg.explorerUrl}
                   />
                 ))}
             </div>
@@ -219,10 +237,7 @@ export default function TransactionDetail({
       </div>
 
       <div className="sticky bottom-0 bg-bg-default px-20 pt-12 pb-32">
-        <Button
-          className="w-full"
-          onClick={() => navigate(`/send?to=${peer}`)}
-        >
+        <Button className="w-full" onClick={() => navigate(`/send?to=${peer}`)}>
           送る
         </Button>
       </div>

--- a/packages/frontend/app/routes/transactions.tsx
+++ b/packages/frontend/app/routes/transactions.tsx
@@ -1,6 +1,6 @@
 import { Search } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useNavigate, useFetcher } from "react-router";
+import { useFetcher, useNavigate } from "react-router";
 import { formatUnits } from "viem";
 import {
   AppBar,
@@ -14,7 +14,8 @@ import { TextField } from "~/components/ui/text-field";
 import { Typography } from "~/components/ui/typography";
 import { useActiveWallet } from "~/hooks/useActiveWallet";
 import { useTransfersViaRouter } from "~/hooks/useTransfersViaRouter";
-import { searchNames, type NameStoneProfile } from "~/lib/namestone.server";
+import { getExplorerName, getExplorerTxUrl } from "~/lib/explorer";
+import { type NameStoneProfile, searchNames } from "~/lib/namestone.server";
 import { formatTimestamp, shortenAddress } from "~/lib/utils";
 import type { Route } from "./+types/transactions";
 
@@ -43,7 +44,8 @@ export default function Transactions() {
   const fetcher = useFetcher<typeof loader>();
   const [query, setQuery] = useState("");
   const { address } = useActiveWallet();
-  const { data: transfers, isLoading: isTransfersLoading } = useTransfersViaRouter(address, 20);
+  const { data: transfers, isLoading: isTransfersLoading } =
+    useTransfersViaRouter(address, 20);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const isSearching = query.length > 0;
@@ -98,7 +100,9 @@ export default function Transactions() {
             <SectionTitle>検索結果</SectionTitle>
             <div className="mt-8">
               {fetcher.state === "loading" ? (
-                <Typography variant="ui-13" className="py-12 text-text-hint">検索中...</Typography>
+                <Typography variant="ui-13" className="py-12 text-text-hint">
+                  検索中...
+                </Typography>
               ) : searchResults && searchResults.length > 0 ? (
                 searchResults.map((profile: NameStoneProfile, i: number) => (
                   <ListRow
@@ -123,9 +127,13 @@ export default function Transactions() {
             <SectionTitle>履歴</SectionTitle>
             <div className="mt-8">
               {isTransfersLoading ? (
-                <Typography variant="ui-13" className="py-12 text-text-hint">読み込み中...</Typography>
+                <Typography variant="ui-13" className="py-12 text-text-hint">
+                  読み込み中...
+                </Typography>
               ) : !transfers || transfers.length === 0 ? (
-                <Typography variant="ui-13" className="py-12 text-text-hint">取引履歴がありません</Typography>
+                <Typography variant="ui-13" className="py-12 text-text-hint">
+                  取引履歴がありません
+                </Typography>
               ) : (
                 transfers.map((tx, i) => {
                   const meLower = address?.toLowerCase() ?? "";
@@ -137,6 +145,7 @@ export default function Transactions() {
                   const signedAmount =
                     (isSent ? -1 : 1) *
                     Number(formatUnits(BigInt(shownAmount), 18));
+                  const explorerUrl = getExplorerTxUrl(tx.transactionHash);
                   return (
                     <ListRow
                       key={tx.id}
@@ -146,6 +155,8 @@ export default function Transactions() {
                       divider={i < transfers.length - 1}
                       onClick={() => navigate(`/transactions/${counterparty}`)}
                       className="cursor-pointer"
+                      externalUrl={explorerUrl ?? undefined}
+                      externalUrlLabel={`${getExplorerName()}で取引を開く`}
                     />
                   );
                 })


### PR DESCRIPTION
## 関連 Issue

Closes #113

## 変更内容

- `lib/explorer.ts`: 現在チェーンに対応する Explorer URL を解決する `getExplorerTxUrl` / `getExplorerAddressUrl` / `getExplorerName` を追加。viem の `chain.blockExplorers` から取得し、Hardhat 等 Explorer 不在のチェーンでは `null` を返す。
- `components/ui/list-row`: 行末に外部リンクアイコンを表示できる `externalUrl` / `externalUrlLabel` プロパティを追加（行クリックを妨げないよう `stopPropagation`）。Ladle ストーリーも追加。
- `routes/send` 完了ステップ: 送金成功時に `txHash` から Explorer リンクを表示。
- `routes/transactions` 履歴一覧: 各行末に Explorer リンクを表示。
- `routes/transactions.\$address` やりとり詳細: メッセージバブル内に Explorer リンクを表示。

## 動作確認

- [ ] ローカル環境で動作確認済み
- [x] 型チェック (`tsc --noEmit`) が通ることを確認済み
- [x] Biome (`biome check`) が通ることを確認済み

ローカル UI 動作確認は未実施です。レビュー時に Sepolia 接続でリンク表示・遷移を確認してください。

## スクリーンショット（該当する場合）

未添付。送金完了画面下部・履歴一覧の右端アイコン・やりとり詳細のバブル内に小さな外部リンクアイコンとして配置。

## その他

ロードマップ A-005 に基づく実装。Hardhat/localhost ではアイコンが表示されない（Explorer URL 不在のため）が、Mainnet / Sepolia / Optimism / Base ではそれぞれの Explorer に遷移します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)