### PR TITLE
feat: ネットワーク不一致時の警告バナーと送金ガード (#119)

### DIFF
--- a/packages/frontend/app/components/chain-mismatch-banner.stories.tsx
+++ b/packages/frontend/app/components/chain-mismatch-banner.stories.tsx
@@ -1,0 +1,86 @@
+import { AlertTriangle } from "lucide-react";
+
+import "~/app.css";
+import { Button } from "~/components/ui/button";
+import { Typography } from "~/components/ui/typography";
+
+export default {
+  title: "Components/ChainMismatchBanner",
+};
+
+function StaticBanner({
+  expectedChainName,
+  walletChainId,
+  switchError,
+  isSwitching,
+}: {
+  expectedChainName: string;
+  walletChainId: number | null;
+  switchError?: string;
+  isSwitching?: boolean;
+}) {
+  return (
+    <div className="mx-auto w-full max-w-md min-h-screen bg-bg-default">
+      <div
+        role="alert"
+        className="flex flex-col gap-8 border-b border-text-danger-default bg-button-danger-frame px-16 py-12 text-button-danger-text-invert"
+      >
+        <div className="flex items-start gap-8">
+          <AlertTriangle
+            size={20}
+            className="mt-2 shrink-0"
+            aria-hidden="true"
+          />
+          <div className="flex flex-col gap-4">
+            <Typography variant="ui-13" weight="bold">
+              ネットワークが {expectedChainName} ではありません
+            </Typography>
+            <Typography variant="ui-13">
+              {walletChainId
+                ? `現在のチェーンID: ${walletChainId}`
+                : "ウォレットのチェーンを確認してください"}
+              。送金前にネットワークを切り替えてください。
+            </Typography>
+            {switchError ? (
+              <Typography variant="ui-13" weight="bold">
+                切替に失敗: {switchError}
+              </Typography>
+            ) : null}
+          </div>
+        </div>
+        <Button
+          variant="secondary"
+          size="sm"
+          disabled={isSwitching}
+          className="self-end"
+        >
+          {isSwitching ? "切替中..." : `${expectedChainName} に切り替える`}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export const Default = () => (
+  <StaticBanner expectedChainName="Sepolia" walletChainId={1} />
+);
+Default.storyName = "Default (Mainnet → Sepolia)";
+
+export const Switching = () => (
+  <StaticBanner expectedChainName="Sepolia" walletChainId={1} isSwitching />
+);
+Switching.storyName = "Switching In-Progress";
+
+export const SwitchFailed = () => (
+  <StaticBanner
+    expectedChainName="Sepolia"
+    walletChainId={1}
+    switchError="ユーザがチェーン切替を拒否しました"
+  />
+);
+SwitchFailed.storyName = "Switch Failed";
+
+export const UnknownChain = () => (
+  <StaticBanner expectedChainName="Sepolia" walletChainId={null} />
+);
+UnknownChain.storyName = "Unknown Chain";

--- a/packages/frontend/app/components/chain-mismatch-banner.tsx
+++ b/packages/frontend/app/components/chain-mismatch-banner.tsx
@@ -1,0 +1,58 @@
+import { AlertTriangle } from "lucide-react";
+
+import { Button } from "~/components/ui/button";
+import { Typography } from "~/components/ui/typography";
+import { useChainMismatch } from "~/hooks/useChainMismatch";
+
+export function ChainMismatchBanner() {
+  const {
+    isMismatched,
+    walletChainId,
+    expectedChainName,
+    isSwitching,
+    switchError,
+    switchToExpected,
+  } = useChainMismatch();
+
+  if (!isMismatched) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      className="flex flex-col gap-8 border-b border-text-danger-default bg-button-danger-frame px-16 py-12 text-button-danger-text-invert"
+    >
+      <div className="flex items-start gap-8">
+        <AlertTriangle size={20} className="mt-2 shrink-0" aria-hidden="true" />
+        <div className="flex flex-col gap-4">
+          <Typography variant="ui-13" weight="bold">
+            ネットワークが {expectedChainName} ではありません
+          </Typography>
+          <Typography variant="ui-13">
+            {walletChainId
+              ? `現在のチェーンID: ${walletChainId}`
+              : "ウォレットのチェーンを確認してください"}
+            。送金前にネットワークを切り替えてください。
+          </Typography>
+          {switchError ? (
+            <Typography variant="ui-13" weight="bold">
+              切替に失敗: {switchError}
+            </Typography>
+          ) : null}
+        </div>
+      </div>
+      <Button
+        variant="secondary"
+        size="sm"
+        disabled={isSwitching}
+        onClick={() => {
+          void switchToExpected();
+        }}
+        className="self-end"
+      >
+        {isSwitching ? "切替中..." : `${expectedChainName} に切り替える`}
+      </Button>
+    </div>
+  );
+}

--- a/packages/frontend/app/hooks/useChainMismatch.ts
+++ b/packages/frontend/app/hooks/useChainMismatch.ts
@@ -1,0 +1,62 @@
+import { useState } from "react";
+
+import { useActiveWallet } from "~/hooks/useActiveWallet";
+import { useWallet } from "~/hooks/useWallet";
+import { currentChain } from "~/lib/viem";
+
+interface ChainMismatchResult {
+  /** Smart Account / Embedded wallet では常に false。外部ウォレットで想定チェーン外のとき true */
+  isMismatched: boolean;
+  /** 外部ウォレットの現在チェーンID。embedded wallet または未接続時は null */
+  walletChainId: number | null;
+  /** アプリが想定しているチェーンID（VITE_CHAIN_ID） */
+  expectedChainId: number;
+  /** 想定チェーンの表示名 */
+  expectedChainName: string;
+  /** 切替リクエスト中かどうか */
+  isSwitching: boolean;
+  /** 直近の switch 失敗エラー */
+  switchError: string | null;
+  /** 想定チェーンへ切替を要求する */
+  switchToExpected: () => Promise<void>;
+}
+
+export function useChainMismatch(): ChainMismatchResult {
+  const { isSmartWallet, isConnectingEmbeddedWallet } = useActiveWallet();
+  const { chainId, switchChain, connectedWallet } = useWallet();
+  const [isSwitching, setIsSwitching] = useState(false);
+  const [switchError, setSwitchError] = useState<string | null>(null);
+
+  const expectedChainId = currentChain.id;
+  const expectedChainName = currentChain.name;
+
+  // Smart Account / Embedded wallet は Privy の defaultChain に固定されているため検出しない
+  const usesEmbedded = isSmartWallet || isConnectingEmbeddedWallet;
+  const hasExternalWallet = !!connectedWallet && !usesEmbedded;
+  const isMismatched =
+    hasExternalWallet && chainId !== null && chainId !== expectedChainId;
+
+  const switchToExpected = async (): Promise<void> => {
+    setSwitchError(null);
+    setIsSwitching(true);
+    try {
+      await switchChain(expectedChainId);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "チェーンの切替に失敗しました";
+      setSwitchError(message);
+    } finally {
+      setIsSwitching(false);
+    }
+  };
+
+  return {
+    isMismatched,
+    walletChainId: hasExternalWallet ? chainId : null,
+    expectedChainId,
+    expectedChainName,
+    isSwitching,
+    switchError,
+    switchToExpected,
+  };
+}

--- a/packages/frontend/app/root.tsx
+++ b/packages/frontend/app/root.tsx
@@ -9,6 +9,7 @@ import {
 import type { Route } from "./+types/root";
 import "./app.css";
 import { AuthGate } from "./components/auth-gate";
+import { ChainMismatchBanner } from "./components/chain-mismatch-banner";
 import { ActiveWalletProvider } from "./providers/ActiveWalletProvider";
 import { AppPrivyProvider } from "./providers/AppPrivyProvider";
 import { QueryProvider } from "./providers/QueryProvider";
@@ -50,6 +51,7 @@ export default function App() {
       <AppPrivyProvider>
         <ActiveWalletProvider>
           <div className="mx-auto w-full max-w-md min-h-screen">
+            <ChainMismatchBanner />
             <AuthGate />
           </div>
         </ActiveWalletProvider>

--- a/packages/frontend/app/routes/send.tsx
+++ b/packages/frontend/app/routes/send.tsx
@@ -14,6 +14,7 @@ import { Label } from "~/components/ui/label";
 import { TextField } from "~/components/ui/text-field";
 import { Typography } from "~/components/ui/typography";
 import { useActiveWallet } from "~/hooks/useActiveWallet";
+import { useChainMismatch } from "~/hooks/useChainMismatch";
 import {
   calculateDistribution,
   grossUpFromRecipient,
@@ -46,7 +47,11 @@ export async function loader({ request }: Route.LoaderArgs) {
     const profile = profiles.length > 0 ? profiles[0] : null;
     return { recipient: { address: to, profile }, initialAmount, initialStory };
   } catch {
-    return { recipient: { address: to, profile: null }, initialAmount, initialStory };
+    return {
+      recipient: { address: to, profile: null },
+      initialAmount,
+      initialStory,
+    };
   }
 }
 
@@ -74,17 +79,11 @@ function AmountRow({
 }) {
   return (
     <div className="flex items-center justify-between rounded-lg bg-background px-16 py-12">
-      <Typography
-        variant="ui-13"
-        weight={bold ? "bold" : "normal"}
-        as="span"
-      >
+      <Typography variant="ui-13" weight={bold ? "bold" : "normal"} as="span">
         {label}
       </Typography>
       <div className="flex items-baseline gap-4">
-        <Typography variant="number-m">
-          {formatAmount(amount)}
-        </Typography>
+        <Typography variant="number-m">{formatAmount(amount)}</Typography>
         <Typography variant="ui-20" weight="bold">
           FoR
         </Typography>
@@ -107,6 +106,8 @@ export default function Send({ loaderData }: Route.ComponentProps) {
     useForTokenBalance(address);
   const { data: ratios, isLoading: isRatiosLoading } = useDistributionRatios();
   const { executeTransfer, status, txHash, error } = useDistributionTransfer();
+  const { isMismatched: isChainMismatched, expectedChainName } =
+    useChainMismatch();
 
   // ユーザー入力 = 受取人が受け取る額（送るFoR）。
   // Router へは grossUp した total を渡して、分配後に recipient 部分が input に一致するようにする。
@@ -155,15 +156,22 @@ export default function Send({ loaderData }: Route.ComponentProps) {
     : "0";
 
   const isSubmitting = status === "signing" || status === "pending";
-  const confirmLabel =
-    status === "signing"
+  const confirmLabel = isChainMismatched
+    ? `${expectedChainName} に切り替えてください`
+    : status === "signing"
       ? "署名中..."
       : status === "pending"
         ? "送信中..."
         : "送る";
 
   const handleConfirmSend = async () => {
-    if (!recipient?.address || totalAmountBigInt === 0n || isSubmitting) return;
+    if (
+      !recipient?.address ||
+      totalAmountBigInt === 0n ||
+      isSubmitting ||
+      isChainMismatched
+    )
+      return;
     const payload = buildMessagePayload({
       usecase: selectedPurpose,
       memo: story,
@@ -235,7 +243,12 @@ export default function Send({ loaderData }: Route.ComponentProps) {
                 placeholder="0"
                 className="min-w-0 flex-1 rounded-md border border-border bg-card px-8 py-6 text-right font-latin text-content-number-m font-bold text-foreground outline-none"
               />
-              <Typography variant="ui-20" weight="bold" as="span" className="shrink-0">
+              <Typography
+                variant="ui-20"
+                weight="bold"
+                as="span"
+                className="shrink-0"
+              >
                 FoR
               </Typography>
             </div>
@@ -255,7 +268,9 @@ export default function Send({ loaderData }: Route.ComponentProps) {
             </div>
 
             <div className="mt-12 flex items-center justify-between">
-              <Typography variant="ui-13" weight="bold" as="span">合計</Typography>
+              <Typography variant="ui-13" weight="bold" as="span">
+                合計
+              </Typography>
               <div className="flex items-baseline gap-4">
                 <Typography variant="number-l">
                   {isRatiosLoading ? "--" : formatAmount(totalAmount)}
@@ -318,7 +333,9 @@ export default function Send({ loaderData }: Route.ComponentProps) {
 
           {/* Story */}
           <div>
-            <Typography variant="ui-16" weight="bold">ストーリー</Typography>
+            <Typography variant="ui-16" weight="bold">
+              ストーリー
+            </Typography>
             <div className="mt-8">
               <TextField
                 placeholder="ストーリーをシェア"
@@ -420,7 +437,9 @@ export default function Send({ loaderData }: Route.ComponentProps) {
             </div>
 
             <div className="flex items-center justify-between pt-4">
-              <Typography variant="ui-13" weight="bold" as="span">合計</Typography>
+              <Typography variant="ui-13" weight="bold" as="span">
+                合計
+              </Typography>
               <div className="flex items-baseline gap-4">
                 <Typography variant="number-l">
                   {formatAmount(totalAmount)}
@@ -449,7 +468,7 @@ export default function Send({ loaderData }: Route.ComponentProps) {
         <div className="sticky bottom-0 bg-bg-default px-20 pt-12 pb-32">
           <Button
             className="w-full"
-            disabled={isSubmitting || !recipient?.address}
+            disabled={isSubmitting || !recipient?.address || isChainMismatched}
             onClick={handleConfirmSend}
           >
             {confirmLabel}
@@ -497,7 +516,9 @@ export default function Send({ loaderData }: Route.ComponentProps) {
             あなたのランク
           </Typography>
           <div className="h-[100px] w-[100px] rounded-lg bg-background" />
-          <Typography variant="ui-16" weight="bold">ランク2</Typography>
+          <Typography variant="ui-16" weight="bold">
+            ランク2
+          </Typography>
           <Typography variant="ui-13" className="text-visual-green-4">
             あと○回交換すると、ランク3にアップ！
           </Typography>


### PR DESCRIPTION
## 関連 Issue

Closes #119

## 変更内容

外部ウォレット（MetaMask 等）が想定チェーン（`VITE_CHAIN_ID`）と異なるネットワークに接続しているときに警告し、ワンクリックで切替できるバナーをアプリ全体に追加。送金画面では不一致時にボタンを無効化してチェーン誤りでの送金を防ぐ。

- `hooks/useChainMismatch`: 外部ウォレットのチェーンを `currentChain.id` と比較。Privy embedded wallet / Smart Account は `AppPrivyProvider.defaultChain` に固定されているため対象外。
- `components/chain-mismatch-banner`: 警告バナー本体と Ladle ストーリー（Default / Switching / SwitchFailed / UnknownChain）。
- `root.tsx`: `AuthGate` 上にバナーを配置（全画面で共通表示）。AppBar も `sticky top-0` のため、レイアウト重なり回避のためバナーは通常フローで配置。
- `routes/send.tsx`: 不一致時は確認ボタンを無効化し「Sepolia に切り替えてください」のような誘導文言を表示。

## 動作確認

- [ ] ローカル環境で動作確認済み（外部ウォレットでの実機確認は未実施）
- [x] 型チェック (`tsc --noEmit`) が通ることを確認済み
- [x] Biome (`biome check`) が通ることを確認済み

UI 動作確認は未実施です。レビュー時に MetaMask を Mainnet に切り替えてバナー表示・切替ボタン動作を確認してください。

## スクリーンショット（該当する場合）

未添付。Ladle (`pnpm ladle:serve`) で `Components/ChainMismatchBanner` から確認できます。

## その他

ロードマップ B-011（誤チェーン送金防止）の実装。Privy embedded wallet 利用時はバナーは表示されません（`AppPrivyProvider.supportedChains` で固定済みのため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)