### PR TITLE
feat: プロフィール編集とアバターIPFSアップロード (#120)

### DIFF
--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -26,6 +26,12 @@ NAMESTONE_API_KEY=your-namestone-api-key-here
 # NameStone ENS Domain (e.g., for.eth)
 NAMESTONE_DOMAIN=for.eth
 
+# Pinata (IPFS) — プロフィール画像アップロードに使用
+# JWT / Gateway / Gateway Token は https://app.pinata.cloud から取得
+VITE_PINATA_JWT=your-pinata-jwt-here
+VITE_PINATA_GATEWAY=your-gateway.mypinata.cloud
+VITE_PINATA_GATEWAY_TOKEN=your-pinata-gateway-token-here
+
 # AllowList 追加署名に使う管理者アカウントの秘密鍵
 # FoRToken の ADMIN_ROLE を持つアドレスの private key（先頭 0x はあっても無くても可）
 # サーバー側 (/api/allowlist/sign) でのみ使用する

--- a/packages/frontend/app/components/ui/avatar.tsx
+++ b/packages/frontend/app/components/ui/avatar.tsx
@@ -2,6 +2,7 @@ import { Plus } from "lucide-react";
 import * as React from "react";
 
 import avatarDefault from "~/assets/images/avatar-default.png";
+import { ipfs2https } from "~/lib/ipfs";
 import { cn } from "~/lib/utils";
 
 const AVATAR_DEFAULT_SRC = avatarDefault;
@@ -13,6 +14,12 @@ const avatarSizeClasses = {
 } as const;
 
 type AvatarSize = keyof typeof avatarSizeClasses;
+
+const resolveAvatarSrc = (src?: string): string | undefined => {
+  if (!src) return undefined;
+  if (src.startsWith("ipfs://")) return ipfs2https(src);
+  return src;
+};
 
 export interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
   src?: string;
@@ -28,9 +35,12 @@ export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
       setImageError(false);
     }, [src]);
 
-    const hasProvidedSrc = Boolean(src);
+    const resolvedSrcCandidate = resolveAvatarSrc(src);
+    const hasProvidedSrc = Boolean(resolvedSrcCandidate);
     const showProvidedImage = hasProvidedSrc && !imageError;
-    const resolvedSrc = showProvidedImage ? src : AVATAR_DEFAULT_SRC;
+    const resolvedSrc = showProvidedImage
+      ? resolvedSrcCandidate
+      : AVATAR_DEFAULT_SRC;
 
     return (
       <div
@@ -55,36 +65,61 @@ export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
 Avatar.displayName = "Avatar";
 
 export interface AvatarUploadProps
-  extends React.HTMLAttributes<HTMLDivElement> {
+  extends Omit<React.HTMLAttributes<HTMLLabelElement>, "onChange"> {
   src?: string;
   alt?: string;
+  onFileSelect?: (file: File) => void;
+  disabled?: boolean;
 }
 
-export const AvatarUpload = React.forwardRef<HTMLDivElement, AvatarUploadProps>(
-  ({ className, src, alt, ...props }, ref) => {
-    return (
-      <div
-        ref={ref}
-        className={cn(
-          "inline-flex size-[120px] shrink-0 flex-col items-center justify-center gap-[10px] rounded-[64px] bg-button-tertiary-frame/90",
-          className,
-        )}
-        {...props}
-      >
-        {src ? (
-          <img
-            src={src}
-            alt={alt ?? ""}
-            className="size-full rounded-full object-cover"
-          />
-        ) : (
-          <>
-            <Plus className="size-24 text-white" />
-            <span className="text-ui-16 font-bold text-white">画像を選択</span>
-          </>
-        )}
-      </div>
-    );
-  },
-);
+export const AvatarUpload = React.forwardRef<
+  HTMLLabelElement,
+  AvatarUploadProps
+>(({ className, src, alt, onFileSelect, disabled, ...props }, ref) => {
+  const resolvedSrc = resolveAvatarSrc(src);
+  const interactive = Boolean(onFileSelect) && !disabled;
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!file.type.startsWith("image/")) {
+      e.target.value = "";
+      return;
+    }
+    onFileSelect?.(file);
+    e.target.value = "";
+  };
+
+  return (
+    <label
+      ref={ref}
+      className={cn(
+        "inline-flex size-[120px] shrink-0 flex-col items-center justify-center gap-[10px] overflow-hidden rounded-[64px] bg-button-tertiary-frame/90",
+        interactive && "cursor-pointer",
+        className,
+      )}
+      {...props}
+    >
+      <input
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={handleChange}
+        disabled={!interactive}
+      />
+      {resolvedSrc ? (
+        <img
+          src={resolvedSrc}
+          alt={alt ?? ""}
+          className="size-full rounded-full object-cover"
+        />
+      ) : (
+        <>
+          <Plus className="size-24 text-white" />
+          <span className="text-ui-16 font-bold text-white">画像を選択</span>
+        </>
+      )}
+    </label>
+  );
+});
 AvatarUpload.displayName = "AvatarUpload";

--- a/packages/frontend/app/hooks/useUploadImageFileToIpfs.ts
+++ b/packages/frontend/app/hooks/useUploadImageFileToIpfs.ts
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { ipfsUploadImageFile } from "~/lib/ipfs";
+
+export interface UploadResult {
+  ipfsCid: string;
+  ipfsUri: string;
+}
+
+export const useUploadImageFileToIpfs = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+
+  const uploadImageFileToIpfs = async (
+    fileToUpload?: File,
+  ): Promise<UploadResult | null> => {
+    const fileToUse = fileToUpload ?? imageFile;
+    if (!fileToUse) return null;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const upload = await ipfsUploadImageFile(fileToUse);
+      return { ipfsCid: upload.cid, ipfsUri: `ipfs://${upload.cid}` };
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error("Upload failed");
+      setError(e);
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    uploadImageFileToIpfs,
+    imageFile,
+    setImageFile,
+    isLoading,
+    error,
+  };
+};

--- a/packages/frontend/app/lib/ipfs.ts
+++ b/packages/frontend/app/lib/ipfs.ts
@@ -1,0 +1,55 @@
+import { PinataSDK } from "pinata";
+
+interface PinataConfig {
+  pinataJwt: string;
+  pinataGateway: string;
+  pinataGatewayToken: string;
+}
+
+const getPinataConfig = (): PinataConfig => {
+  const pinataJwt = import.meta.env.VITE_PINATA_JWT;
+  const pinataGateway = import.meta.env.VITE_PINATA_GATEWAY;
+  const pinataGatewayToken = import.meta.env.VITE_PINATA_GATEWAY_TOKEN;
+
+  if (!pinataJwt) {
+    throw new Error("VITE_PINATA_JWT is not defined");
+  }
+  if (!pinataGateway) {
+    throw new Error("VITE_PINATA_GATEWAY is not defined");
+  }
+  if (!pinataGatewayToken) {
+    throw new Error("VITE_PINATA_GATEWAY_TOKEN is not defined");
+  }
+
+  return { pinataJwt, pinataGateway, pinataGatewayToken };
+};
+
+let ipfsClient: PinataSDK | null = null;
+
+export const createIpfsClient = (): PinataSDK => {
+  if (ipfsClient) return ipfsClient;
+
+  const { pinataJwt, pinataGateway } = getPinataConfig();
+  ipfsClient = new PinataSDK({ pinataJwt, pinataGateway });
+  return ipfsClient;
+};
+
+export const ipfsUploadFile = async (file: File) => {
+  const client = createIpfsClient();
+  return client.upload.public.file(file);
+};
+
+export const ipfsUploadImageFile = async (imageFile: File) => {
+  if (!imageFile?.type.startsWith("image/")) {
+    throw new Error("Invalid or no image file selected");
+  }
+  return ipfsUploadFile(imageFile);
+};
+
+export const ipfs2https = (ipfsUri?: string): string | undefined => {
+  if (!ipfsUri) return undefined;
+  if (!ipfsUri.startsWith("ipfs://")) return ipfsUri;
+  const { pinataGateway, pinataGatewayToken } = getPinataConfig();
+  const cid = ipfsUri.replace("ipfs://", "");
+  return `https://${pinataGateway}/ipfs/${cid}?pinataGatewayToken=${pinataGatewayToken}`;
+};

--- a/packages/frontend/app/routes/profile.create.tsx
+++ b/packages/frontend/app/routes/profile.create.tsx
@@ -1,12 +1,12 @@
 import { ens_normalize } from "@adraffy/ens-normalize";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
-  Form,
   redirect,
   useActionData,
   useFetcher,
   useNavigate,
   useNavigation,
+  useSubmit,
 } from "react-router";
 import {
   AppBar,
@@ -17,9 +17,10 @@ import {
 import { AvatarUpload } from "~/components/ui/avatar";
 import { Button } from "~/components/ui/button";
 import { TextField } from "~/components/ui/text-field";
-import { useActiveWallet } from "~/hooks/useActiveWallet";
-import { searchNames, setName } from "~/lib/namestone.server";
 import { Typography } from "~/components/ui/typography";
+import { useActiveWallet } from "~/hooks/useActiveWallet";
+import { useUploadImageFileToIpfs } from "~/hooks/useUploadImageFileToIpfs";
+import { searchNames, setName } from "~/lib/namestone.server";
 import type { Route } from "./+types/profile.create";
 
 export function meta(_args: Route.MetaArgs) {
@@ -53,12 +54,10 @@ export async function action({ request }: Route.ActionArgs) {
   const name = (formData.get("name") as string)?.trim();
   const address = formData.get("address") as string;
   const avatar = (formData.get("avatar") as string)?.trim();
-  const display = (formData.get("display") as string)?.trim();
   const description = (formData.get("description") as string)?.trim();
 
   const errors: Record<string, string> = {};
 
-  // Validate name
   if (!name) {
     errors.name = "ユーザー名を入力してください";
   } else if (name.length < 3) {
@@ -75,22 +74,18 @@ export async function action({ request }: Route.ActionArgs) {
     }
   }
 
-  // Validate address
   if (!address || !/^0x[a-fA-F0-9]{40}$/.test(address)) {
     errors.address = "ウォレットが接続されていません";
   }
 
-  // Validate avatar
-  if (avatar && !avatar.startsWith("https://")) {
-    errors.avatar = "URLはhttps://で始めてください";
+  if (
+    avatar &&
+    !avatar.startsWith("ipfs://") &&
+    !avatar.startsWith("https://")
+  ) {
+    errors.avatar = "プロフィール画像のURLが不正です";
   }
 
-  // Validate display name
-  if (display && display.length > 50) {
-    errors.display = "ニックネームは50文字以内にしてください";
-  }
-
-  // Validate description
   if (description && description.length > 200) {
     errors.description = "自己紹介は200文字以内にしてください";
   }
@@ -99,7 +94,6 @@ export async function action({ request }: Route.ActionArgs) {
     return { errors };
   }
 
-  // Check availability
   try {
     const existing = await searchNames(name, true);
     if (existing.length > 0) {
@@ -109,14 +103,12 @@ export async function action({ request }: Route.ActionArgs) {
     return { errors: { name: "ユーザー名の確認中にエラーが発生しました" } };
   }
 
-  // Create profile
   try {
     await setName({
       name,
       address,
       textRecords: {
         avatar: avatar || undefined,
-        display: display || undefined,
         description: description || undefined,
       },
     });
@@ -132,16 +124,31 @@ export default function ProfileCreate() {
   const navigation = useNavigation();
   const navigate = useNavigate();
   const fetcher = useFetcher<typeof loader>();
+  const submit = useSubmit();
   const { address } = useActiveWallet();
 
+  const {
+    uploadImageFileToIpfs,
+    imageFile,
+    setImageFile,
+    isLoading: isUploading,
+    error: uploadError,
+  } = useUploadImageFileToIpfs();
+
   const [username, setUsername] = useState("");
-  const [avatarUrl, setAvatarUrl] = useState("");
+  const [description, setDescription] = useState("");
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  const isSubmitting = navigation.state === "submitting";
+  const previewUrl = imageFile ? URL.createObjectURL(imageFile) : undefined;
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
+
+  const isSubmitting = navigation.state !== "idle" || isUploading;
   const errors = actionData?.errors;
 
-  // Client-side ENS normalize check
   const [clientError, setClientError] = useState<string | null>(null);
 
   const validateAndCheckName = useCallback(
@@ -164,7 +171,6 @@ export default function ProfileCreate() {
         return;
       }
 
-      // Debounced availability check
       if (debounceRef.current) clearTimeout(debounceRef.current);
       debounceRef.current = setTimeout(() => {
         fetcher.load(`/profile/create?check=${encodeURIComponent(value)}`);
@@ -179,7 +185,6 @@ export default function ProfileCreate() {
     };
   }, []);
 
-  // Determine username field status
   const availabilityData = fetcher.data;
   let nameHelperText: string | undefined;
   let nameErrorText = errors?.name ?? clientError ?? undefined;
@@ -196,6 +201,29 @@ export default function ProfileCreate() {
     nameHelperText = "確認中...";
   }
 
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (!address || !username) return;
+
+      let avatarUri: string | undefined;
+      if (imageFile) {
+        const res = await uploadImageFileToIpfs();
+        if (!res) return;
+        avatarUri = res.ipfsUri;
+      }
+
+      const formData = new FormData();
+      formData.set("name", username);
+      formData.set("address", address);
+      formData.set("description", description);
+      if (avatarUri) formData.set("avatar", avatarUri);
+
+      submit(formData, { method: "post" });
+    },
+    [address, username, description, imageFile, uploadImageFileToIpfs, submit],
+  );
+
   return (
     <div className="min-h-screen bg-bg-default">
       <AppBar>
@@ -207,22 +235,23 @@ export default function ProfileCreate() {
         </AppBarItem>
       </AppBar>
 
-      <Form method="post" className="flex flex-col items-center gap-24 px-20 py-24">
-        <input type="hidden" name="address" value={address ?? ""} />
-
-        {/* Avatar */}
-        <AvatarUpload src={avatarUrl || undefined} alt="プロフィール画像" />
-
-        <TextField
-          name="avatar"
-          label="プロフィール画像URL"
-          placeholder="https://..."
-          value={avatarUrl}
-          onChange={(e) => setAvatarUrl(e.target.value)}
-          errorText={errors?.avatar}
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col items-center gap-24 px-20 py-24"
+      >
+        <AvatarUpload
+          src={previewUrl}
+          alt="プロフィール画像"
+          onFileSelect={setImageFile}
+          disabled={isSubmitting}
         />
 
-        {/* Username */}
+        {uploadError && (
+          <Typography variant="ui-13" className="text-text-danger-default">
+            画像のアップロードに失敗しました
+          </Typography>
+        )}
+
         <TextField
           name="name"
           label="ユーザー名"
@@ -238,19 +267,12 @@ export default function ProfileCreate() {
           required
         />
 
-        {/* Display name */}
-        <TextField
-          name="display"
-          label="ニックネーム"
-          placeholder="表示名"
-          errorText={errors?.display}
-        />
-
-        {/* Bio */}
         <TextField
           name="description"
           label="自己紹介"
           placeholder="自己紹介を入力"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
           errorText={errors?.description}
         />
 
@@ -260,14 +282,24 @@ export default function ProfileCreate() {
           </Typography>
         )}
 
+        {errors?.avatar && (
+          <Typography variant="ui-13" className="text-text-danger-default">
+            {errors.avatar}
+          </Typography>
+        )}
+
         <Button
           type="submit"
           disabled={isSubmitting || !address || !username}
           className="w-full"
         >
-          {isSubmitting ? "作成中..." : "プロフィールを作成"}
+          {isUploading
+            ? "画像アップロード中..."
+            : navigation.state !== "idle"
+              ? "作成中..."
+              : "プロフィールを作成"}
         </Button>
-      </Form>
+      </form>
     </div>
   );
 }

--- a/packages/frontend/app/routes/profile.edit.tsx
+++ b/packages/frontend/app/routes/profile.edit.tsx
@@ -1,11 +1,11 @@
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
-  Form,
   redirect,
   useActionData,
   useLoaderData,
   useNavigate,
   useNavigation,
+  useSubmit,
 } from "react-router";
 import {
   AppBar,
@@ -16,8 +16,9 @@ import {
 import { AvatarUpload } from "~/components/ui/avatar";
 import { Button } from "~/components/ui/button";
 import { TextField } from "~/components/ui/text-field";
-import { getNamesByAddress, setName } from "~/lib/namestone.server";
 import { Typography } from "~/components/ui/typography";
+import { useUploadImageFileToIpfs } from "~/hooks/useUploadImageFileToIpfs";
+import { getNamesByAddress, setName } from "~/lib/namestone.server";
 import type { Route } from "./+types/profile.edit";
 
 export function meta(_args: Route.MetaArgs) {
@@ -48,7 +49,6 @@ export async function action({ request }: Route.ActionArgs) {
   const name = formData.get("name") as string;
   const address = formData.get("address") as string;
   const avatar = (formData.get("avatar") as string)?.trim();
-  const display = (formData.get("display") as string)?.trim();
   const description = (formData.get("description") as string)?.trim();
 
   const errors: Record<string, string> = {};
@@ -57,12 +57,12 @@ export async function action({ request }: Route.ActionArgs) {
     errors.address = "ウォレットが接続されていません";
   }
 
-  if (avatar && !avatar.startsWith("https://")) {
-    errors.avatar = "URLはhttps://で始めてください";
-  }
-
-  if (display && display.length > 50) {
-    errors.display = "ニックネームは50文字以内にしてください";
+  if (
+    avatar &&
+    !avatar.startsWith("ipfs://") &&
+    !avatar.startsWith("https://")
+  ) {
+    errors.avatar = "プロフィール画像のURLが不正です";
   }
 
   if (description && description.length > 200) {
@@ -79,7 +79,6 @@ export async function action({ request }: Route.ActionArgs) {
       address,
       textRecords: {
         avatar: avatar || undefined,
-        display: display || undefined,
         description: description || undefined,
       },
     });
@@ -95,13 +94,60 @@ export default function ProfileEdit() {
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
   const navigate = useNavigate();
+  const submit = useSubmit();
 
-  const [avatarUrl, setAvatarUrl] = useState(
-    profile.text_records?.avatar ?? "",
-  );
+  const {
+    uploadImageFileToIpfs,
+    imageFile,
+    setImageFile,
+    isLoading: isUploading,
+    error: uploadError,
+  } = useUploadImageFileToIpfs();
 
-  const isSubmitting = navigation.state === "submitting";
+  const initialAvatar = profile.text_records?.avatar ?? "";
+  const initialDescription = profile.text_records?.description ?? "";
+  const [description, setDescription] = useState(initialDescription);
+
+  const previewUrl = imageFile ? URL.createObjectURL(imageFile) : undefined;
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
+
+  const displayAvatarSrc = previewUrl ?? initialAvatar ?? undefined;
+  const isSubmitting = navigation.state !== "idle" || isUploading;
   const errors = actionData?.errors;
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+
+      let avatarUri = initialAvatar;
+      if (imageFile) {
+        const res = await uploadImageFileToIpfs();
+        if (!res) return;
+        avatarUri = res.ipfsUri;
+      }
+
+      const formData = new FormData();
+      formData.set("name", profile.name);
+      formData.set("address", profile.address);
+      formData.set("description", description);
+      if (avatarUri) formData.set("avatar", avatarUri);
+
+      submit(formData, { method: "post" });
+    },
+    [
+      profile.name,
+      profile.address,
+      description,
+      imageFile,
+      initialAvatar,
+      uploadImageFileToIpfs,
+      submit,
+    ],
+  );
 
   return (
     <div className="min-h-screen bg-bg-default">
@@ -114,44 +160,31 @@ export default function ProfileEdit() {
         </AppBarItem>
       </AppBar>
 
-      <Form method="post" className="flex flex-col items-center gap-24 px-20 py-24">
-        <input type="hidden" name="name" value={profile.name} />
-        <input type="hidden" name="address" value={profile.address} />
-
-        {/* Avatar */}
-        <AvatarUpload src={avatarUrl || undefined} alt="プロフィール画像" />
-
-        <TextField
-          name="avatar"
-          label="プロフィール画像URL"
-          placeholder="https://..."
-          value={avatarUrl}
-          onChange={(e) => setAvatarUrl(e.target.value)}
-          errorText={errors?.avatar}
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col items-center gap-24 px-20 py-24"
+      >
+        <AvatarUpload
+          src={displayAvatarSrc}
+          alt="プロフィール画像"
+          onFileSelect={setImageFile}
+          disabled={isSubmitting}
         />
 
-        {/* Username (read-only) */}
-        <TextField
-          label="ユーザー名"
-          value={profile.name}
-          readOnly
-        />
+        {uploadError && (
+          <Typography variant="ui-13" className="text-text-danger-default">
+            画像のアップロードに失敗しました
+          </Typography>
+        )}
 
-        {/* Display name */}
-        <TextField
-          name="display"
-          label="ニックネーム"
-          placeholder="表示名"
-          defaultValue={profile.text_records?.display ?? ""}
-          errorText={errors?.display}
-        />
+        <TextField label="ユーザー名" value={profile.name} readOnly />
 
-        {/* Bio */}
         <TextField
           name="description"
           label="自己紹介"
           placeholder="自己紹介を入力"
-          defaultValue={profile.text_records?.description ?? ""}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
           errorText={errors?.description}
         />
 
@@ -161,14 +194,20 @@ export default function ProfileEdit() {
           </Typography>
         )}
 
-        <Button
-          type="submit"
-          disabled={isSubmitting}
-          className="w-full"
-        >
-          {isSubmitting ? "保存中..." : "保存"}
+        {errors?.avatar && (
+          <Typography variant="ui-13" className="text-text-danger-default">
+            {errors.avatar}
+          </Typography>
+        )}
+
+        <Button type="submit" disabled={isSubmitting} className="w-full">
+          {isUploading
+            ? "画像アップロード中..."
+            : navigation.state !== "idle"
+              ? "保存中..."
+              : "保存"}
         </Button>
-      </Form>
+      </form>
     </div>
   );
 }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -26,6 +26,7 @@
     "isbot": "^5.1.31",
     "lucide-react": "^0.554.0",
     "permissionless": "^0.2.57",
+    "pinata": "^2.5.5",
     "qrcode.react": "^4.2.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       permissionless:
         specifier: ^0.2.57
         version: 0.2.57(viem@2.43.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      pinata:
+        specifier: ^2.5.5
+        version: 2.5.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       qrcode.react:
         specifier: ^4.2.0
         version: 4.2.0(react@19.2.0)
@@ -4432,7 +4435,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -5974,6 +5977,18 @@ packages:
   pify@5.0.0:
     resolution: {integrity: sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==}
     engines: {node: '>=10'}
+
+  pinata@2.5.5:
+    resolution: {integrity: sha512-GmHGL8bSpiwQlbrXrT73DJ1ZrYi+MD3lY7scY10D2PnH0kggDCUP04Gb96thbRenhvqVYjPRYYFt7gW9yjejYw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   pinkie-promise@2.0.1:
     resolution: {integrity: sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==}
@@ -16212,6 +16227,11 @@ snapshots:
   pify@3.0.0: {}
 
   pify@5.0.0: {}
+
+  pinata@2.5.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    optionalDependencies:
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
 
   pinkie-promise@2.0.1:
     dependencies:


### PR DESCRIPTION
## 関連 Issue

Closes #120

## 変更内容

プロフィール編集画面 (`/profile/edit`) を実装し、Pinata IPFS による画像アップロードで `AvatarUpload` を更新。`profile.create` と `profile.edit` の両方を同じフロー（ファイル選択 → IPFS アップロード → NameStone `setName`）に統一しました。

- `lib/ipfs.ts`: Pinata SDK クライアントと `ipfs://` → HTTPS リゾルバ (`ipfs2https`) を追加
- `hooks/useUploadImageFileToIpfs`: 画像アップロード状態管理（imageFile / isLoading / error）
- `components/ui/avatar`:
  - `Avatar` が `ipfs://` を Pinata gateway URL に解決
  - `AvatarUpload` をファイル入力（`<input type="file">`）に置き換え
  - 非インタラクティブ時も `<input>` を常時レンダ（disabled）にして a11y `noLabelWithoutControl` を解消
- `routes/profile.create`: ファイル選択フローへ移行。不要になった `display` テキスト記録を廃止
- `routes/profile.edit`: 編集画面の loader / action / 画像アップロード処理を実装
- `.env.example`: `VITE_PINATA_JWT` / `VITE_PINATA_GATEWAY` / `VITE_PINATA_GATEWAY_TOKEN` を追加
- 依存追加: `pinata@^2.5.5`

## 動作確認

- [ ] ローカル環境で動作確認済み（実機 IPFS アップロードは未実施）
- [x] 型チェック (`tsc --noEmit`) が通ることを確認済み
- [x] Biome (`biome check`) が通ることを確認済み（`useExhaustiveDependencies` の `[src]` は main からの既存指摘）

レビュー時に Pinata 認証情報を `.env` に設定の上、画像選択 → アップロード → 保存 → mypage 反映を確認してください。

## スクリーンショット（該当する場合）

未添付。

## その他

ロードマップ B-014 の実装。同時にロードマップ B-015（アバター画像アップロード）の主要部分も含みます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)