### PR TITLE
feat: アカウント削除フローを実装 (#121)

### DIFF
--- a/packages/frontend/app/routes/mypage.tsx
+++ b/packages/frontend/app/routes/mypage.tsx
@@ -1,16 +1,12 @@
-import { useEffect } from "react";
 import { usePrivy } from "@privy-io/react-auth";
+import { useEffect } from "react";
 import { Link, useFetcher, useNavigate } from "react-router";
-import {
-  AppBar,
-  AppBarItem,
-  AppBarTitle,
-} from "~/components/ui/app-bar";
+import { AppBar, AppBarItem, AppBarTitle } from "~/components/ui/app-bar";
 import { Avatar } from "~/components/ui/avatar";
 import { Button } from "~/components/ui/button";
+import { Typography } from "~/components/ui/typography";
 import { useActiveWallet } from "~/hooks/useActiveWallet";
 import type { NameStoneProfile } from "~/lib/namestone.server";
-import { Typography } from "~/components/ui/typography";
 import type { Route } from "./+types/mypage";
 
 export function meta(_args: Route.MetaArgs) {
@@ -50,7 +46,9 @@ export default function Mypage() {
           </AppBarItem>
         </AppBar>
         <div className="flex items-center justify-center py-32">
-          <Typography variant="ui-13" className="text-text-hint">読み込み中...</Typography>
+          <Typography variant="ui-13" className="text-text-hint">
+            読み込み中...
+          </Typography>
         </div>
       </div>
     );
@@ -129,6 +127,17 @@ export default function Mypage() {
         <Button variant="secondary" className="w-full" onClick={handleLogout}>
           ログアウト
         </Button>
+
+        {profile ? (
+          <Link
+            to={`/settings/delete-account?address=${address}`}
+            className="w-full"
+          >
+            <Button variant="ghost" className="w-full text-text-danger-default">
+              アカウントを削除
+            </Button>
+          </Link>
+        ) : null}
       </div>
     </div>
   );

--- a/packages/frontend/app/routes/settings.delete-account.tsx
+++ b/packages/frontend/app/routes/settings.delete-account.tsx
@@ -1,13 +1,202 @@
+import { usePrivy } from "@privy-io/react-auth";
+import { useEffect, useState } from "react";
+import { redirect, useFetcher, useLoaderData, useNavigate } from "react-router";
+
+import {
+  AppBar,
+  AppBarBackButton,
+  AppBarItem,
+  AppBarTitle,
+} from "~/components/ui/app-bar";
+import { Button } from "~/components/ui/button";
+import { Typography } from "~/components/ui/typography";
+import {
+  deleteName,
+  getNamesByAddress,
+  type NameStoneProfile,
+} from "~/lib/namestone.server";
 import type { Route } from "./+types/settings.delete-account";
 
 export function meta(_args: Route.MetaArgs) {
   return [{ title: "アカウント削除 | FoR" }];
 }
 
+export async function loader({ request }: Route.LoaderArgs) {
+  const url = new URL(request.url);
+  const address = url.searchParams.get("address");
+  if (!address) {
+    return redirect("/mypage");
+  }
+  try {
+    const profiles = await getNamesByAddress(address);
+    const profile = profiles[0] ?? null;
+    return { profile, address };
+  } catch {
+    return { profile: null as NameStoneProfile | null, address };
+  }
+}
+
+interface ActionData {
+  success?: boolean;
+  error?: string;
+}
+
+export async function action({
+  request,
+}: Route.ActionArgs): Promise<ActionData> {
+  const formData = await request.formData();
+  const name = (formData.get("name") as string)?.trim();
+  if (!name) {
+    return { error: "プロフィール名がありません" };
+  }
+  try {
+    await deleteName(name);
+    return { success: true };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "削除に失敗しました";
+    return { error: message };
+  }
+}
+
 export default function SettingsDeleteAccount() {
+  const navigate = useNavigate();
+  const { profile, address } = useLoaderData<typeof loader>();
+  const { logout } = usePrivy();
+  const fetcher = useFetcher<ActionData>();
+
+  const [confirmed, setConfirmed] = useState(false);
+  const isDeleting = fetcher.state !== "idle";
+  const deleteSuccess = fetcher.data?.success === true;
+  const deleteError = fetcher.data?.error;
+
+  // 削除成功 → ログアウト → ホームへ
+  useEffect(() => {
+    if (!deleteSuccess) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        await logout();
+      } finally {
+        if (!cancelled) navigate("/", { replace: true });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [deleteSuccess, logout, navigate]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!profile?.name || !confirmed || isDeleting) return;
+    const formData = new FormData();
+    formData.set("name", profile.name);
+    fetcher.submit(formData, {
+      method: "post",
+      action: `/settings/delete-account?address=${encodeURIComponent(address)}`,
+    });
+  };
+
   return (
-    <div>
-      <h1>アカウント削除</h1>
+    <div className="min-h-screen bg-bg-default">
+      <AppBar>
+        <AppBarItem position="left">
+          <AppBarBackButton onClick={() => navigate(-1)} />
+        </AppBarItem>
+        <AppBarItem position="center">
+          <AppBarTitle>アカウント削除</AppBarTitle>
+        </AppBarItem>
+      </AppBar>
+
+      <div className="flex flex-col gap-24 px-20 py-24">
+        <Typography variant="ui-16" weight="bold">
+          アカウントの削除について
+        </Typography>
+
+        <div className="flex flex-col gap-12 rounded-lg bg-background p-16">
+          <Typography variant="ui-13" weight="bold">
+            削除されるもの
+          </Typography>
+          <ul className="ml-16 list-disc text-ui-13 text-text-default">
+            <li>プロフィール（名前・アイコン・自己紹介）</li>
+            <li>NameStone 上のドメイン登録</li>
+          </ul>
+
+          <Typography variant="ui-13" weight="bold" className="pt-8">
+            削除されないもの（重要）
+          </Typography>
+          <ul className="ml-16 list-disc text-ui-13 text-text-default">
+            <li>
+              ブロックチェーンに記録された送受信履歴・金額・タイムスタンプ
+            </li>
+            <li>
+              受取人としてオンチェーンに記録された相手側のトランザクション
+            </li>
+          </ul>
+          <Typography variant="ui-13" className="text-text-subtle">
+            これらはブロックチェーンの性質上、削除できません。アカウントを削除しても、過去の取引はチェーン上に残り続けます。
+          </Typography>
+        </div>
+
+        {!profile ? (
+          <Typography variant="ui-13" className="text-text-hint">
+            プロフィールが見つかりませんでした。
+          </Typography>
+        ) : (
+          <form
+            onSubmit={handleSubmit}
+            className="flex flex-col gap-16 rounded-lg bg-background p-16"
+          >
+            <Typography variant="ui-13" className="text-text-default">
+              削除対象:{" "}
+              <strong>
+                {profile.name}.{profile.domain}
+              </strong>
+            </Typography>
+
+            <label className="flex items-start gap-8 text-ui-13 text-text-default">
+              <input
+                type="checkbox"
+                checked={confirmed}
+                onChange={(e) => setConfirmed(e.target.checked)}
+                className="mt-4 size-16"
+              />
+              <span>
+                上記の内容を理解し、アカウントを削除することに同意します。
+              </span>
+            </label>
+
+            {deleteError ? (
+              <Typography variant="ui-13" className="text-text-danger-default">
+                削除に失敗しました: {deleteError}
+              </Typography>
+            ) : null}
+
+            <Button
+              type="submit"
+              variant="destructive"
+              disabled={!confirmed || isDeleting || deleteSuccess}
+              className="w-full"
+            >
+              {deleteSuccess
+                ? "削除しました"
+                : isDeleting
+                  ? "削除中..."
+                  : "アカウントを削除する"}
+            </Button>
+
+            <Button
+              type="button"
+              variant="secondary"
+              className="w-full"
+              onClick={() => navigate(-1)}
+              disabled={isDeleting || deleteSuccess}
+            >
+              キャンセル
+            </Button>
+          </form>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 関連 Issue

Closes #121

## 変更内容

`/settings/delete-account` 画面を実装し、退会前に「ブロックチェーンに残るデータ」と「削除されるデータ」を明示。確認チェックボックスを満たした後に NameStone のプロフィールを削除し、Privy ログアウト → ホームへ遷移します。

- `routes/settings.delete-account`:
  - **loader**: `?address=` から対象プロフィール（NameStone）を取得。未指定なら `/mypage` にリダイレクト。
  - **action**: `deleteName(profile.name)` を呼び出し、結果（success / error）を返す。
  - **UI**: 削除されるもの／チェーンに残るものを並列表示。確認チェック → 削除ボタン → ログアウト → `/` 遷移の順。
- `routes/mypage`: 「アカウントを削除」リンクを追加（destructive 文字色 + ghost variant）。
- 削除ボタンは確認チェック前は無効化。エラー時は文言表示 + 再試行可能。

## 動作確認

- [ ] ローカル環境で動作確認済み（NameStone API での削除実行は未検証）
- [x] 型チェック (`tsc --noEmit`) が通ることを確認済み
- [x] Biome (`biome check`) が通ることを確認済み

レビュー時に NameStone 設定の上で実機確認をお願いします。注意点: 削除実行後は対象アカウントで再ログインしても allowlist は残るため、再オンボーディングはプロフィール作成のみに見えます（仕様）。

## スクリーンショット（該当する場合）

未添付。

## その他

ロードマップ B-016（個人情報保護法/GDPR 対応の最低ライン）の実装。オンチェーンデータが残る旨を明示することで、ロードマップ O-005（オンチェーンデータと法的削除要求のギャップ説明）の一部を満たします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)