### PR TITLE
feat(contract): AllowList を送信者のみ制限し受取は許可する

### DIFF
--- a/packages/contract/contracts/FoRToken.sol
+++ b/packages/contract/contracts/FoRToken.sol
@@ -97,33 +97,35 @@ contract FoRToken is ERC20, ERC20Permit, AccessControl {
 
     // ============ Transfer Restrictions ============
 
-    /// @notice Override transfer to enforce allow list
+    /// @notice Override transfer to enforce allow list on the sender only
+    /// @dev Only the sender must be allow listed; recipients can receive freely.
     function transfer(
         address to,
         uint256 amount
     ) public virtual override returns (bool) {
-        _requireBothAllowListed(_msgSender(), to);
+        _requireSenderAllowListed(_msgSender());
         return super.transfer(to, amount);
     }
 
-    /// @notice Override transferFrom to enforce allow list
+    /// @notice Override transferFrom to enforce allow list on the sender only
+    /// @dev Only the token owner (`from`) must be allow listed; recipients can receive freely.
     function transferFrom(
         address from,
         address to,
         uint256 amount
     ) public virtual override returns (bool) {
-        _requireBothAllowListed(from, to);
+        _requireSenderAllowListed(from);
         return super.transferFrom(from, to, amount);
     }
 
     // ============ Internal Functions ============
 
-    /// @notice Require both addresses to be on the allow list
+    /// @notice Require the sending address to be on the allow list
+    /// @dev Recipients are intentionally not checked so that any wallet can
+    ///      receive tokens; spending requires allow list membership.
     /// @param from Sender address
-    /// @param to Recipient address
-    function _requireBothAllowListed(address from, address to) internal view {
+    function _requireSenderAllowListed(address from) internal view {
         if (!_allowList[from]) revert NotAllowListed(from);
-        if (!_allowList[to]) revert NotAllowListed(to);
     }
 
     // ============ ERC165 Interface Support ============

--- a/packages/contract/contracts/FoRToken.t.sol
+++ b/packages/contract/contracts/FoRToken.t.sol
@@ -350,18 +350,24 @@ contract FoRTokenTest is Test {
         token.transfer(user1, 50 ether);
     }
 
-    function test_Transfer_RevertsIfRecipientNotAllowListed() public {
+    function test_Transfer_SucceedsIfRecipientNotAllowListed() public {
         address notAllowListed = address(0x100);
-        
-        vm.expectRevert(abi.encodeWithSelector(FoRToken.NotAllowListed.selector, notAllowListed));
-        token.transfer(notAllowListed, 100 ether);
+        uint256 amount = 100 ether;
+
+        // Recipient is not on the allow list but should still be able to receive.
+        token.transfer(notAllowListed, amount);
+
+        require(
+            token.balanceOf(notAllowListed) == amount,
+            "non-allow-listed recipient should receive tokens"
+        );
     }
 
-    function test_Transfer_SucceedsIfBothAllowListed() public {
+    function test_Transfer_SucceedsIfSenderAllowListed() public {
         uint256 amount = 100 ether;
-        
+
         token.transfer(user1, amount);
-        
+
         require(token.balanceOf(user1) == amount, "transfer should succeed");
     }
 
@@ -381,24 +387,30 @@ contract FoRTokenTest is Test {
         token.transferFrom(notAllowListed, user2, 50 ether);
     }
 
-    function test_TransferFrom_RevertsIfToNotAllowListed() public {
+    function test_TransferFrom_SucceedsIfToNotAllowListed() public {
         address notAllowListed = address(0x100);
-        
+        uint256 amount = 50 ether;
+
         token.approve(user1, 100 ether);
-        
+
+        // Recipient is not on the allow list but should still be able to receive.
         vm.prank(user1);
-        vm.expectRevert(abi.encodeWithSelector(FoRToken.NotAllowListed.selector, notAllowListed));
-        token.transferFrom(deployer, notAllowListed, 50 ether);
+        token.transferFrom(deployer, notAllowListed, amount);
+
+        require(
+            token.balanceOf(notAllowListed) == amount,
+            "non-allow-listed recipient should receive tokens"
+        );
     }
 
-    function test_TransferFrom_SucceedsIfBothAllowListed() public {
+    function test_TransferFrom_SucceedsIfFromAllowListed() public {
         uint256 amount = 100 ether;
-        
+
         token.approve(user1, amount);
-        
+
         vm.prank(user1);
         token.transferFrom(deployer, user2, amount);
-        
+
         require(token.balanceOf(user2) == amount, "transfer should succeed");
     }
 


### PR DESCRIPTION
## 関連 Issue

Closes #151

## 変更内容

AllowList の譲渡制限を「送信者のみ制限・受取は許可」へ変更しました。

- `_requireBothAllowListed(from, to)` を `_requireSenderAllowListed(from)` へ変更し、**送信者(from)のみ** AllowList 必須に
- `transfer` / `transferFrom` を更新（受取人(to)は AllowList 登録不要で受け取れる）
- 未登録アドレス宛の送金が成功することを検証するテストへ更新（`test_Transfer_SucceedsIfRecipientNotAllowListed` / `test_TransferFrom_SucceedsIfToNotAllowListed`）

これにより「とりあえず受け取っておき、使いたいときに AllowList へ登録すれば送れる」体験になり、オンボーディングの摩擦を下げます。

## 動作確認

- [x] テストが通ることを確認済み（`pnpm test` 全 70 件 passing、Solidity テスト含む）
- [x] ビルドが成功することを確認済み

## その他

- mint は従来どおり制限対象外（公開関数 override のため内部 mint は通る）。
- Router 経由の分配送金（基金/Burn/受取人）も新ルールで成功することをテストで確認済み。
