### PR TITLE
feat(frontend): リストコンポーネントのデザイン修正 (#139)

### DIFF
--- a/packages/frontend/app/components/ui/list-row.tsx
+++ b/packages/frontend/app/components/ui/list-row.tsx
@@ -1,9 +1,9 @@
 import { ExternalLink } from "lucide-react";
 import * as React from "react";
 
+import { Avatar } from "~/components/ui/avatar";
 import { CURRENCY_LABEL } from "~/lib/currency";
 import { formatAmount } from "~/lib/format";
-import { ipfs2https } from "~/lib/ipfs";
 import { cn } from "~/lib/utils";
 
 export interface ListRowProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -49,28 +49,17 @@ export const ListRow = React.forwardRef<HTMLDivElement, ListRowProps>(
     },
     ref,
   ) => {
-    const resolvedAvatarSrc = avatarSrc?.startsWith("ipfs://")
-      ? ipfs2https(avatarSrc)
-      : avatarSrc;
     return (
       <div
         ref={ref}
         className={cn(
-          "flex items-center gap-12 p-14 bg-background rounded-[10px]",
+          "flex items-center gap-12 px-16 py-18 bg-background rounded-[10px]",
           className,
         )}
         data-slot="list-row"
         {...props}
       >
-        {resolvedAvatarSrc ? (
-          <div className="flex size-40 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted">
-            <img
-              src={resolvedAvatarSrc}
-              alt={avatarAlt}
-              className="size-40 rounded-full object-cover"
-            />
-          </div>
-        ) : null}
+        <Avatar src={avatarSrc} alt={avatarAlt} size="sm" />
 
         {/* Left content: name + message */}
         <div className="flex min-w-0 flex-1 flex-col gap-4">


### PR DESCRIPTION
## 概要

Issue #139 のリストコンポーネント・デザイン修正。

森の再生基金画面＞みんなの貢献履歴リスト と あなたのウォレット画面＞履歴リストは、いずれも共通の `ListRow` コンポーネントを利用しているため、`ListRow` を修正することで両方のリストに反映されます。

## 変更内容

- サムネイル未設定時にデフォルトのサムネイル画像を表示
  - アバター描画を `Avatar` コンポーネントに統一し、未設定／読み込み失敗時にデフォルト画像（`avatar-default.png`）へフォールバック
  - 併せて ipfs:// 解決ロジックの重複を解消
- padding を 左右16px・上下18px に変更（`px-16 py-18`）
- border-radius は 10px を維持（`rounded-[10px]`）

## 確認

- `tsc --noEmit` 通過
- `biome check` 通過

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)