### PR TITLE
feat(frontend): section-titleのデザイン修正 (#140)

### DIFF
--- a/packages/frontend/app/components/ui/section-title.tsx
+++ b/packages/frontend/app/components/ui/section-title.tsx
@@ -3,8 +3,8 @@ import * as React from "react";
 import { cn } from "~/lib/utils";
 
 const titleVariantClasses = {
-  large: "font-ui text-ui-20 font-bold",
-  small: "font-ui text-ui-16 font-bold",
+  large: "font-ui text-ui-20 font-normal",
+  small: "font-ui text-ui-16 font-normal",
 } as const;
 
 export type SectionTitleProps = React.ComponentPropsWithoutRef<"div"> & {
@@ -27,7 +27,10 @@ export const SectionTitle = React.forwardRef<HTMLDivElement, SectionTitleProps>(
   ) => {
     return (
       <div
-        className={cn("flex items-center justify-between gap-8", className)}
+        className={cn(
+          "flex items-center justify-between gap-8 py-8",
+          className,
+        )}
         data-slot="section-title"
         ref={ref}
         {...props}


### PR DESCRIPTION
## 関連 Issue

Closes #140

## 変更内容

共通コンポーネント `SectionTitle` のデザインを修正しました。これにより、当該コンポーネントを利用する全画面の section-title に反映されます（あなたのウォレット画面・送る/受け取る画面・森の再生基金画面）。

- section-title の文字 weight を `bold` → `normal` に変更
- section-title に上下 padding 8px (`py-8`) を追加

## 動作確認

- [ ] ローカル環境で動作確認済み
- [x] テストが通ることを確認済み（biome check / tsc --noEmit パス）
- [x] ビルドが成功することを確認済み

## スクリーンショット（該当する場合）

## その他

- マイページ画面の「設定」「その他」は現状未実装のため、今回は対象外です。今後 `SectionTitle` を用いて実装すれば本デザインが自動的に反映されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)